### PR TITLE
layer_entity_value_max: turns 0.0 into null

### DIFF
--- a/api/v1/class.layer.php
+++ b/api/v1/class.layer.php
@@ -311,9 +311,9 @@
         /**
          * @param string $key
          * @param mixed|null $val
-         * @return string|null
+         * @return mixed|null
          */
-        private function metaValueValidation(string $key, $val): ?string
+        private function metaValueValidation(string $key, $val)
 		{	
 			// all key-based validation first		
 			$convertZeroToNull = [

--- a/api/v1/class.layer.php
+++ b/api/v1/class.layer.php
@@ -308,12 +308,17 @@
 			}
 		}
 
-		private function MetaValueValidation($key, $val)
+        /**
+         * @param string $key
+         * @param mixed|null $val
+         * @return string|null
+         */
+        private function metaValueValidation(string $key, $val): ?string
 		{	
 			// all key-based validation first		
-			$convertZeroToNull = array(
-				"layer_entity_value_max" // float - used to convert 0.0 to null
-			);			
+			$convertZeroToNull = [
+				'layer_entity_value_max' // float - used to convert 0.0 to null
+			];
 			if (in_array($key, $convertZeroToNull)) {
 				if (empty($val)) {
 					return null; // meaning: null returned if value was "", null, 0, 0.0 or false
@@ -321,11 +326,14 @@
 			}
 			
 			// all value-based validation second
-			if (is_array($val)) {
-				return json_encode($val);
+			if (is_array($val) || is_object($val)) {
+				if (false === $result = json_encode($val)) {
+                    return '';
+                }
+                return $result;
 			}
 			if ($val == null) {
-				return "";
+				return '';
 			}
 			
 			return $val;
@@ -358,7 +366,7 @@
 				}
 				else{
 					$inserts .= $key . "=?, ";
-					array_push($insertarr, $this->MetaValueValidation($key, $val));
+					array_push($insertarr, $this->metaValueValidation($key, $val));
 				}
 			}
 

--- a/api/v1/class.layer.php
+++ b/api/v1/class.layer.php
@@ -308,38 +308,57 @@
 			}
 		}
 
+		private function MetaValueValidation($key, $val)
+		{	
+			// all key-based validation first		
+			$convertZeroToNull = array(
+				"layer_entity_value_max" // float - used to convert 0.0 to null
+			);			
+			if (in_array($key, $convertZeroToNull)) {
+				if (empty($val)) {
+					return null; // meaning: null returned if value was "", null, 0, 0.0 or false
+				}
+			}
+			
+			// all value-based validation second
+			if (is_array($val)) {
+				return json_encode($val);
+			}
+			if ($val == null) {
+				return "";
+			}
+			
+			return $val;
+		}
+
 		private function ImportMetaForLayer(array $layerData, int $dbLayerId)
 		{
+			//these meta vars are to be ignored in the importer
+			$ignoreList = array(
+				"layer_id",
+				"layer_name",
+				"layer_original_id",
+				"layer_raster",
+				"layer_width",
+				"layer_height",
+				"layer_raster_material",
+				"layer_raster_pattern",
+				"layer_raster_minimum_value_cutoff",
+				"layer_raster_color_interpolation",
+				"layer_raster_filter_mode",
+				"approval",
+				"layer_download_from_geoserver"
+			);
+
 			$inserts = "";
 			$insertarr = array();
-			foreach($layerData as $key => $val){
-				//these keys are to be ignored in the importer
-				if($key == "layer_id" || 
-					$key == "layer_name" || 
-					$key == "layer_original_id" || 
-					$key == "layer_raster" || 
-					$key == "layer_width" || 
-					$key == "layer_height" || 
-					$key == "layer_raster_material" || 
-					$key == "layer_raster_pattern" ||
-					$key == "layer_raster_minimum_value_cutoff" ||
-					$key == "layer_raster_color_interpolation" ||
-					$key == "layer_raster_filter_mode" ||
-					$key == "approval" || 
-					$key == "layer_download_from_geoserver" ) {
+			foreach($layerData as $key => $val) {
+				if (in_array($key, $ignoreList)) {
 					continue;
 				}
 				else{
 					$inserts .= $key . "=?, ";
-					if(is_array($val)){
-						array_push($insertarr, json_encode($val));
-					}
-					else{
-						if($val != null)
-							array_push($insertarr, $val);
-						else
-							array_push($insertarr, "");
-					}
+					array_push($insertarr, $this->MetaValueValidation($key, $val));
 				}
 			}
 


### PR DESCRIPTION
Makes necessary (but presumably temporary) changes to server API's layer class to turn 0.0 values of layer_entity_value_max into null. At some point in the future the CradleConfigEditor will be able to handle setting null values to floats, at which point we will have a neater solution.