### PR TITLE
added another phpcs (code sniffer) through composer for easy setup with your editor (automatic)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,5 +12,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: MSPChallenge-Server
+      - name: Install dependencies
+        uses: php-actions/composer@master
+        with:
+          php_version: 7.4
       - name: run linters
         run: cd MSPChallenge-Server && ./test.sh

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Install dependencies
         uses: php-actions/composer@master
         with:
+          path: MSPChallenge-Server
           php_version: 7.4
       - name: run linters
         run: cd MSPChallenge-Server && ./test.sh

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,10 +12,5 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: MSPChallenge-Server
-      - name: Install dependencies
-        uses: php-actions/composer@master
-        with:
-          path: MSPChallenge-Server
-          php_version: 7.4
       - name: run linters
         run: cd MSPChallenge-Server && ./test.sh

--- a/composer-symfony5.4.json
+++ b/composer-symfony5.4.json
@@ -96,7 +96,7 @@
         "brainmaestro/composer-git-hooks": "^2.8",
         "symfony/stopwatch": "5.4.*",
         "symfony/web-profiler-bundle": "5.4.*",
-	    "squizlabs/php_codesniffer": "3.*"
+        "squizlabs/php_codesniffer": "3.*"
     },
     "repositories": [
         {

--- a/composer-symfony5.4.json
+++ b/composer-symfony5.4.json
@@ -95,7 +95,8 @@
     "require-dev": {
         "brainmaestro/composer-git-hooks": "^2.8",
         "symfony/stopwatch": "5.4.*",
-        "symfony/web-profiler-bundle": "5.4.*"
+        "symfony/web-profiler-bundle": "5.4.*",
+	    "squizlabs/php_codesniffer": "3.*"
     },
     "repositories": [
         {

--- a/composer-symfony5.4.lock
+++ b/composer-symfony5.4.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa4ac85a3a6074a921dc6dd9ba13140d",
+    "content-hash": "0519b81410ad272bbd037783759e90bb",
     "packages": [
         {
             "name": "cboden/ratchet",
@@ -812,7 +812,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v8.83.8",
+            "version": "v8.83.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -866,7 +866,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v8.83.8",
+            "version": "v8.83.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -914,7 +914,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v8.83.8",
+            "version": "v8.83.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -3211,16 +3211,16 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v1.18.5",
+            "version": "v1.18.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "10e438f53a972439675dc720706f0cd5c0ed94f1"
+                "reference": "130851b90c1ea615ac5be6fce827971f4f55afbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/10e438f53a972439675dc720706f0cd5c0ed94f1",
-                "reference": "10e438f53a972439675dc720706f0cd5c0ed94f1",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/130851b90c1ea615ac5be6fce827971f4f55afbf",
+                "reference": "130851b90c1ea615ac5be6fce827971f4f55afbf",
                 "shasum": ""
             },
             "require": {
@@ -3256,7 +3256,7 @@
             "description": "Composer plugin for Symfony",
             "support": {
                 "issues": "https://github.com/symfony/flex/issues",
-                "source": "https://github.com/symfony/flex/tree/v1.18.5"
+                "source": "https://github.com/symfony/flex/tree/v1.18.6"
             },
             "funding": [
                 {
@@ -3272,7 +3272,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-16T17:26:46+00:00"
+            "time": "2022-04-15T08:20:34+00:00"
         },
         {
             "name": "symfony/framework-bundle",
@@ -4746,6 +4746,62 @@
                 "source": "https://github.com/BrainMaestro/composer-git-hooks/tree/v2.8.5"
             },
             "time": "2021-02-08T15:59:11+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2021-12-12T21:44:58+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/symfony5.4.lock
+++ b/symfony5.4.lock
@@ -104,6 +104,15 @@
     "ringcentral/psr7": {
         "version": "1.3.0"
     },
+    "squizlabs/php_codesniffer": {
+        "version": "3.6",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "3.6",
+            "ref": "1019e5c08d4821cb9b77f4891f8e9c31ff20ac6f"
+        }
+    },
     "symfony/cache": {
         "version": "v5.4.0"
     },

--- a/test.sh
+++ b/test.sh
@@ -2,19 +2,15 @@
 set -e
 
 function summary() {
-  ./var/tools/phpcs --standard=PSR2 --report=summary "$1"
+  ./vendor/bin/phpcs --standard=PSR2 --report=summary "$1"
 }
 
 function lint() {
-  ./var/tools/phpcs --standard=PSR2 "$1" -s
-}
-
-function detectMess() {
-./var/tools/phpmd "$1" text cleancode,codesize,controversial
+  ./vendor/bin/phpcs --standard=PSR2 "$1" -s
 }
 
 function fix() {
-  ./var/tools/phpcbf --standard=PSR2 "$1"
+  ./vendor/bin/phpcbf --standard=PSR2 "$1"
 }
 
 PATHS="
@@ -33,7 +29,6 @@ ServerManager/logout.php
 ServerManager/manager.php
 "
 
-bash ./tools/install-tools.sh
 for p in $PATHS
 do
   if [[ "$1" == "--fix" ]]; then

--- a/test.sh
+++ b/test.sh
@@ -2,15 +2,15 @@
 set -e
 
 function summary() {
-  ./vendor/bin/phpcs --standard=PSR2 --report=summary "$1"
+  ./var/tools/phpcs --standard=PSR2 --report=summary "$1"
 }
 
 function lint() {
-  ./vendor/bin/phpcs --standard=PSR2 "$1" -s
+  ./var/tools/phpcs --standard=PSR2 "$1" -s
 }
 
 function fix() {
-  ./vendor/bin/phpcbf --standard=PSR2 "$1"
+  ./var/tools/phpcbf --standard=PSR2 "$1"
 }
 
 PATHS="
@@ -29,6 +29,7 @@ ServerManager/logout.php
 ServerManager/manager.php
 "
 
+bash ./tools/install-tools.sh
 for p in $PATHS
 do
   if [[ "$1" == "--fix" ]]; then

--- a/tools/install-tools.sh
+++ b/tools/install-tools.sh
@@ -43,6 +43,14 @@ if [[ $FORCE == 1 ]]; then
 fi
 
 function download() {
+  # install platform independent tools -- runs on both Linux Ubuntu or Windows Git bash
+  if [[ $FORCE == 1 || ! -f "${DOWNLOAD_DIR}phpcs.phar" ]]; then
+    curl --create-dirs -Lso "${DOWNLOAD_DIR}phpcs.phar" https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+  fi
+  if [[ $FORCE == 1|| ! -f "${DOWNLOAD_DIR}phpcbf.phar" ]]; then
+    curl --create-dirs -Lso "${DOWNLOAD_DIR}phpcbf.phar" https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar
+  fi
+
   # install Windows tools
   if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
     # install Symfony cli
@@ -84,5 +92,25 @@ CONTENT
   fi
 }
 
+function makeExecutable() {
+  TARGET_FILE="${DOWNLOAD_DIR}${1}"
+  cat > "${TARGET_FILE}" <<- CONTENT
+#!/bin/bash
+SCRIPT_DIR="\$( cd -- "\$( dirname -- "\${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+php "\${SCRIPT_DIR}/$1.phar" "\$@"
+CONTENT
+  chmod u+x "${TARGET_FILE}"
+}
+
+function makeExecutables() {
+  if [[ $FORCE == 1 || ! -f phpcs ]]; then
+    makeExecutable phpcs
+  fi
+  if [[ $FORCE == 1 || ! -f phpcbf ]]; then
+    makeExecutable phpcbf
+  fi
+}
+
 download
+makeExecutables
 cd "${CWD}" || exit 5

--- a/tools/install-tools.sh
+++ b/tools/install-tools.sh
@@ -43,17 +43,6 @@ if [[ $FORCE == 1 ]]; then
 fi
 
 function download() {
-  # install platform independent tools -- runs on both Linux unbuntu or Windows Git bash
-  if [[ $FORCE == 1 || ! -f "${DOWNLOAD_DIR}phpcs.phar" ]]; then
-    curl --create-dirs -Lso "${DOWNLOAD_DIR}phpcs.phar" https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
-  fi
-  if [[ $FORCE == 1 || ! -f "${DOWNLOAD_DIR}phpmd.phar" ]]; then
-   curl --create-dirs -Lso "${DOWNLOAD_DIR}phpmd.phar" https://phpmd.org/static/latest/phpmd.phar
-  fi
-  if [[ $FORCE == 1|| ! -f "${DOWNLOAD_DIR}phpcbf.phar" ]]; then
-    curl --create-dirs -Lso "${DOWNLOAD_DIR}phpcbf.phar" https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar
-  fi
-
   # install Windows tools
   if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
     # install Symfony cli
@@ -95,28 +84,5 @@ CONTENT
   fi
 }
 
-function makeExecutable() {
-  TARGET_FILE="${DOWNLOAD_DIR}${1}"
-  cat > "${TARGET_FILE}" <<- CONTENT
-#!/bin/bash
-SCRIPT_DIR="\$( cd -- "\$( dirname -- "\${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-php "\${SCRIPT_DIR}/$1.phar" "\$@"
-CONTENT
-  chmod u+x "${TARGET_FILE}"
-}
-
-function makeExecutables() {
-  if [[ $FORCE == 1 || ! -f phpcs ]]; then
-    makeExecutable phpcs
-  fi
-  if [[ $FORCE == 1 || ! -f phpcbf ]]; then
-    makeExecutable phpcbf
-  fi
-  if [[ $FORCE == 1 || ! -f phpmd ]]; then
-    makeExecutable phpmd
-  fi
-}
-
 download
-makeExecutables
 cd "${CWD}" || exit 5


### PR DESCRIPTION
* removed unused php tool "php mess dectector"
* added php code sniffer using composer.json , now required on dev. It can be *automatically used* by your editor, e.g. phpstorm . So, far more easier setup. After composer install vendor/bin will hold phpcs and phpcbf working for both Windows and Linux
* I kept the other one which we download ourselves using install-tools.sh as well since that one it easier to use from Github work-flow since it has no composer dependency.