### PR TITLE
iteration 2 of handling composer git hook issues

### DIFF
--- a/tools/cghooks-fresh-install.sh
+++ b/tools/cghooks-fresh-install.sh
@@ -26,8 +26,12 @@ then
     exit 4
 fi
 
-./vendor/bin/cghooks remove -f post-merge pre-push
+# remove hooks here that we did use, but do not want to use anymore, e.g.
+# ./vendor/bin/cghooks remove -f post-merge pre-push
+
+# this will add hooks that need updating
 ./vendor/bin/cghooks add --ignore-lock
+
 result=$?
 if [ $result -ne 0 ]
 then


### PR DESCRIPTION
do not remove hooks everytime. since cghooks vendor can not detect if the file content of the hook is unchanged and does not need an update