### PR TITLE
fix for the "healthy" retrieving game session ids, and/or only the "playing" ones. Removed usage of doDummyQuery.

### DIFF
--- a/src/Domain/WsServer/Plugins/Tick/TickWsServerPlugin.php
+++ b/src/Domain/WsServer/Plugins/Tick/TickWsServerPlugin.php
@@ -38,7 +38,7 @@ class TickWsServerPlugin extends Plugin
      */
     private function tick(): PromiseInterface
     {
-        return $this->getServerManager()->getGameSessionIds()
+        return $this->getServerManager()->getGameSessionIds(true)
             ->then(function (Result $result) {
                 $gameSessionIds = collect($result->fetchAllRows() ?? [])
                     ->keyBy('id')

--- a/src/Domain/WsServer/ServerManagerInterface.php
+++ b/src/Domain/WsServer/ServerManagerInterface.php
@@ -7,6 +7,6 @@ use React\Promise\PromiseInterface;
 
 interface ServerManagerInterface
 {
-    public function getGameSessionIds(): PromiseInterface;
+    public function getGameSessionIds(bool $onlyPlaying = false): PromiseInterface;
     public function getAsyncDatabase(int $gameSessionId): Connection;
 }


### PR DESCRIPTION
* only retieve the game session ids that are "healthy"
* added option to only retrieve game session ids "playing" which are the game states: play, fastforward and simulation
* remove doDummyQuery call in "registerLoop", does not exist anymore. Is now handled by DriftPHP itself using "keep alive", see ConnectionPoolOptions class