### PR TITLE
Tested and fixed using From40beta7To40beta10 api call

### DIFF
--- a/src/Domain/Common/CommonBase.php
+++ b/src/Domain/Common/CommonBase.php
@@ -29,7 +29,7 @@ abstract class CommonBase
         if (null === $this->asyncDatabase) {
             // fail-safe: try to create an async database from current request information if there is no instance set.
             if (GameSession::INVALID_SESSION_ID === $gameSessionId = $this->getGameSessionId()) {
-                throw new Exception('Missing required async database connection.');
+                throw new Exception('Missing required game session id for creating an async database connection');
             }
             $this->asyncDatabase = ConnectionManager::getInstance()->getCachedAsyncGameSessionDbConnection(
                 Loop::get(),


### PR DESCRIPTION
so I tested "From40beta7To40beta10" using the URL
http://localhost/1/api/update/From40beta7To40beta10
with a small code modification (changed Security::ACCESS_LEVEL_FLAG_SERVER_MANAGER to
Security::ACCESS_LEVEL_FLAG_NONE)

Bug-fixes:
* improved the error message when you call the api without specifying the game session id. e.g. /api/.. instead of /1/api/..
* caught the "duplicate column" dpo error exception. Calling From40beta7To40beta9 will through this error if you have already migrated to beta8 or -9 already. Which is bad, since that would prevent the further migration to beta10. With this fix From40beta7To40beta10 can be called from beta7-9 and the database will be migrated to beta 10 .
* little feature: added the result of a succeeded migration. So this will be part of the api payload output now . eg.:

{"header_type":null,"header_data":null,"success":true,"message":null,"payload":"\r\n [OK] Already at the latest version (\u0022DoctrineMigrations\\Version20220413200747\u0022)