### PR TITLE
Recovery after crash during executing batch

### DIFF
--- a/ServerManager/classes/Base.php
+++ b/ServerManager/classes/Base.php
@@ -1,6 +1,8 @@
 <?php
 
-class Base 
+use App\Domain\Helper\Config;
+
+class Base
 {
     protected $_jwt;
 

--- a/ServerManager/classes/DB.php
+++ b/ServerManager/classes/DB.php
@@ -17,6 +17,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+use App\Domain\Helper\Config;
+
 class DB {
 	private static $_instance = null;
 	private $_pdo, $_query, $_error = false, $_errorInfo, $_results=[], $_resultsArray=[], $_count = 0, $_lastId, $_queryCount=0;

--- a/ServerManager/classes/Token.php
+++ b/ServerManager/classes/Token.php
@@ -17,6 +17,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+use App\Domain\Helper\Config;
+
 class Token {
 	public static function generate(){
 		return Session::put(Config::get('session/token_name'), md5(uniqid()));

--- a/ServerManager/classes/User.php
+++ b/ServerManager/classes/User.php
@@ -17,6 +17,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+use App\Domain\Helper\Config;
+
 class User extends Base {
 	private $_db, $_data, $_sessionName, $_isLoggedIn, $_cookieName,$_isNewAccount;
 	public $tableName = 'users';

--- a/ServerManager/helpers.php
+++ b/ServerManager/helpers.php
@@ -1,6 +1,8 @@
 <?php
 //functions that help things along. by definition functions that are so common or fundamental, require limited and diverse arguments, it makes no sense to turn them into classes
 
+use App\Domain\Helper\Config;
+
 function getPublicObjectVars($obj) {
   return get_object_vars($obj);
 }

--- a/ServerManager/login.php
+++ b/ServerManager/login.php
@@ -1,4 +1,7 @@
 <?php
+
+use App\Domain\Helper\Config;
+
 if (isset($_SESSION)) {
     session_destroy();
 }

--- a/api/v1/mysql_structure.sql
+++ b/api/v1/mysql_structure.sql
@@ -748,6 +748,8 @@ CREATE TABLE IF NOT EXISTS `msp`.`api_batch` (
   `api_batch_state` enum('Setup','Queued','Executing','Success','Failed') NOT NULL DEFAULT 'Setup',
   `api_batch_country_id` int NOT NULL,
   `api_batch_user_id` int NOT NULL,
+  `api_batch_server_id` varchar(255) NULL,
+  `api_batch_communicated` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`api_batch_id`),
   KEY `api_batch_country_id` (`api_batch_country_id`),
   KEY `api_batch_user_id` (`api_batch_user_id`),

--- a/composer-symfony5.4.json
+++ b/composer-symfony5.4.json
@@ -12,6 +12,7 @@
         "ext-json": "*",
         "ext-pdo": "*",
         "ext-zip": "*",
+        "ext-intl": "*",
         "cboden/ratchet": "^0.4",
         "clue/http-proxy-react": "^1.7",
         "drift/dbal": "dev-master",
@@ -49,7 +50,8 @@
     "autoload": {
         "psr-4": {
             "App\\": "src/",
-            "DoctrineMigrations\\": "migrations/src/"
+            "DoctrineMigrations\\": "migrations/src/",
+            "ServerManager\\": "ServerManager/classes/"
         },
         "files": [
             "src/functions.php",

--- a/migrations/Version20211208135721.php
+++ b/migrations/Version20211208135721.php
@@ -22,27 +22,18 @@ final class Version20211208135721 extends MSPMigration
         return new MSPDatabaseType(MSPDatabaseType::DATABASE_TYPE_GAME_SESSION);
     }
 
+    /**
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
     protected function onUp(Schema $schema): void
     {
-        $table = $schema->getTable('layer');
-        if ($table->hasColumn('layer_entity_value_max')) {
-            $this->write('Column layer_entity_value_max for table layer already exists');
-            return;
-        }
-        $table->addColumn('layer_entity_value_max', Types::FLOAT, [
+        $this->addColumn($schema->getTable('layer'), 'layer_entity_value_max', Types::FLOAT, [
             'Notnull' => false
         ]);
-        $this->write('Added column layer_entity_value_max to table layer');
     }
 
     protected function onDown(Schema $schema): void
     {
-        $table = $schema->getTable('layer');
-        if (!$table->hasColumn('layer_entity_value_max')) {
-            $this->write('Column layer_entity_value_max for table layer already gone');
-            return;
-        }
-        $table->dropColumn('layer_entity_value_max');
-        $this->write('Dropped column layer_entity_value_max from table layer');
+        $this->dropColumn($schema->getTable('layer'), 'layer_entity_value_max');
     }
 }

--- a/migrations/Version20220413200747.php
+++ b/migrations/Version20220413200747.php
@@ -36,18 +36,7 @@ SQL;
         $this->addSql($sql);
 
         $table = $schema->getTable('api_batch');
-        if (!$table->hasColumn('api_batch_country_id')) {
-            $column = $table->addColumn('api_batch_country_id', Types::INTEGER);
-            $this->write("Added column {$column->getName()} for table {$table->getName()}");
-        } else {
-            $column = $table->getColumn('api_batch_country_id');
-            $this->write("Column api_batch_country_id for table {$table->getName()} already exists");
-        }
-
-        $numIndexes = count($table->getIndexes()) + count($table->getForeignKeys());
-        // add missing indexes if any
-        $table->hasIndex($column->getName()) or
-            $table->addIndex([$column->getName()], $column->getName());
+        $column = $this->addIndexedColumn($table, 'api_batch_country_id', Types::INTEGER);
         $table->hasForeignKey('api_batch_ibfk_1') or
             $table->addForeignKeyConstraint(
                 'country',
@@ -57,16 +46,7 @@ SQL;
                 'api_batch_ibfk_1'
             );
 
-        if (!$table->hasColumn('api_batch_user_id')) {
-            $column = $table->addColumn('api_batch_user_id', Types::INTEGER);
-            $this->write("Added column {$column->getName()} for table {$table->getName()}");
-        } else {
-            $column = $table->getColumn('api_batch_user_id');
-            $this->write("Column api_batch_user_id for table {$table->getName()} already exists");
-        }
-
-        // add missing indexes if any
-        $table->hasIndex($column->getName()) or $table->addIndex([$column->getName()], $column->getName());
+        $column = $this->addIndexedColumn($table, 'api_batch_user_id', Types::INTEGER);
         $table->hasForeignKey('api_batch_ibfk_2') or
             $table->addForeignKeyConstraint(
                 'user',
@@ -75,13 +55,11 @@ SQL;
                 ['onDelete' => 'no action', 'onUpdate' => 'no action'],
                 'api_batch_ibfk_2'
             );
-
-        $addedIndexes = count($table->getIndexes()) + count($table->getForeignKeys()) - $numIndexes;
-        if ($addedIndexes > 0) {
-            $this->write("Added {$addedIndexes} missing indexes.");
-        }
     }
 
+    /**
+     * @throws SchemaException
+     */
     protected function onDown(Schema $schema): void
     {
         $sql = <<< 'SQL'
@@ -92,23 +70,10 @@ SQL;
         $this->addSql($sql);
 
         $table = $schema->getTable('api_batch');
-        $numIndexes = count($table->getIndexes()) + count($table->getForeignKeys());
-        $numColumns = count($table->getColumns());
-        !$table->hasIndex('api_batch_country_id') or $table->dropIndex('api_batch_country_id');
         !$table->hasForeignKey('api_batch_ibfk_1') or $table->removeForeignKey('api_batch_ibfk_1');
-        !$table->hasColumn('api_batch_country_id') or $table->dropColumn('api_batch_country_id');
+        $this->dropIndexedColumn($table, 'api_batch_country_id');
 
-        !$table->hasIndex('api_batch_user_id') or $table->dropIndex('api_batch_user_id');
         !$table->hasForeignKey('api_batch_ibfk_2') or $table->removeForeignKey('api_batch_ibfk_2');
-        !$table->hasColumn('api_batch_user_id') or $table->dropColumn('api_batch_user_id');
-
-        $droppedIndexes = $numIndexes - count($table->getIndexes()) + count($table->getForeignKeys());
-        if ($droppedIndexes > 0) {
-            $this->write("Dropped {$droppedIndexes} indexes.");
-        }
-        $droppedColumns = $numColumns - count($table->getColumns());
-        if ($droppedColumns > 0) {
-            $this->write("Dropped {$droppedColumns} columns.");
-        }
+        $this->dropIndexedColumn($table, 'api_batch_user_id');
     }
 }

--- a/migrations/Version20220607114759.php
+++ b/migrations/Version20220607114759.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\DBAL\Types\Types;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220607114759 extends MSPMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add column api_batch_server_id, api_batch_communicated to api_batch';
+    }
+
+    protected function getDatabaseType(): ?MSPDatabaseType
+    {
+        return new MSPDatabaseType(MSPDatabaseType::DATABASE_TYPE_GAME_SESSION);
+    }
+
+    /**
+     * @throws SchemaException
+     */
+    protected function onUp(Schema $schema): void
+    {
+        $table = $schema->getTable('api_batch');
+        $this->addIndexedColumn($table, 'api_batch_server_id', Types::STRING);
+        $this->addColumn($table, 'api_batch_communicated', Types::BOOLEAN)->setDefault(false);
+    }
+
+    /**
+     * @throws SchemaException
+     */
+    protected function onDown(Schema $schema): void
+    {
+        $table = $schema->getTable('api_batch');
+        $this->dropIndexedColumn($table, 'api_batch_server_id');
+        $this->dropColumn($table, 'api_batch_communicated');
+    }
+}

--- a/migrations/Version20220607114759.php
+++ b/migrations/Version20220607114759.php
@@ -29,7 +29,7 @@ final class Version20220607114759 extends MSPMigration
     protected function onUp(Schema $schema): void
     {
         $table = $schema->getTable('api_batch');
-        $this->addIndexedColumn($table, 'api_batch_server_id', Types::STRING);
+        $this->addIndexedColumn($table, 'api_batch_server_id', Types::STRING)->setNotnull(false);
         $this->addColumn($table, 'api_batch_communicated', Types::BOOLEAN)->setDefault(false);
     }
 

--- a/migrations/src/MSPMigration.php
+++ b/migrations/src/MSPMigration.php
@@ -3,8 +3,16 @@
 namespace DoctrineMigrations;
 
 use App\Domain\Helper\Util;
+use Closure;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use http\Message;
+use IntlException;
+use MessageFormatter;
+use function msgfmt_create;
 
 abstract class MSPMigration extends AbstractMigration
 {
@@ -46,16 +54,145 @@ abstract class MSPMigration extends AbstractMigration
         $this->databaseType = $this->getDatabaseType();
     }
 
+    protected function countIndexes(Schema $schema): int
+    {
+        $numIndexes = 0;
+        $tables = $schema->getTables();
+        foreach ($tables as $table) {
+            $numIndexes += count($table->getIndexes()) + count($table->getForeignKeys());
+        }
+        return $numIndexes;
+    }
+
+    protected function countColumns(Schema $schema): int
+    {
+        $numColumns = 0;
+        $tables = $schema->getTables();
+        foreach ($tables as $table) {
+            $numColumns += count($table->getColumns());
+        }
+        return $numColumns;
+    }
+
     public function up(Schema $schema): void
     {
-        $this->validateSchema($schema);
-        $this->onUp($schema);
+        $this->migrate($schema, function () use ($schema) {
+            $this->onUp($schema);
+        });
     }
 
     public function down(Schema $schema): void
     {
+        $this->migrate($schema, function () use ($schema) {
+            $this->onDown($schema);
+        });
+    }
+
+    private function migrate(Schema $schema, Closure $migrationFunction)
+    {
         $this->validateSchema($schema);
-        $this->onDown($schema);
+
+        // collect data to detect changes after migration
+        $numTables = count($schema->getTables());
+        $numColumns = $this->countColumns($schema);
+        $numIndexes = $this->countIndexes($schema);
+
+        // execute migration
+        $migrationFunction();
+
+        // detect and output changes automatically
+        $this->writeDifferences(
+            count($schema->getTables()) - $numTables,
+            $this->countColumns($schema) - $numColumns,
+            $this->countIndexes($schema) - $numIndexes
+        );
+    }
+
+    /**
+     * @throws IntlException
+     */
+    private function writeDifferences(int $numTablesDiff, int $numColumnsDiff, int $numIndexesDiff)
+    {
+        // see https://www.php.net/manual/en/messageformatter.formatmessage.php#112661
+        if ($numTablesDiff != 0) {
+            $this->write(
+                $this->createMessageFormatter(
+                    'en_US',
+                    '{0, choice, ' . PHP_INT_MIN . ' #Dropped| 0 #Added} {1, plural, =1{# table} other{# tables}}'
+                )
+                ->format([$numTablesDiff, abs($numTablesDiff)])
+            );
+        }
+        if ($numColumnsDiff != 0) {
+            $this->write(
+                $this->createMessageFormatter(
+                    'en_US',
+                    '{0, choice, ' . PHP_INT_MIN . ' #Dropped| 0 #Added} {1, plural, =1{# column} other{# columns}}'
+                )
+                ->format([$numColumnsDiff, abs($numColumnsDiff)])
+            );
+        }
+        if ($numIndexesDiff != 0) {
+            $this->write(
+                $this->createMessageFormatter(
+                    'en_US',
+                    '{0, choice, ' . PHP_INT_MIN . ' #Dropped| 0 #Added} {1, plural, =1{# index} other{# indexes}}'
+                )
+                ->format([$numIndexesDiff, abs($numIndexesDiff)])
+            );
+        }
+    }
+
+    /**
+     * @throws IntlException
+     */
+    private function createMessageFormatter($locale, $pattern): MessageFormatter
+    {
+        return new MessageFormatter($locale, $pattern);
+    }
+
+    /**
+     * @throws SchemaException
+     */
+    protected function addColumn(Table $table, string $columnName, string $typeName, array $options = []): Column
+    {
+        if (!$table->hasColumn($columnName)) {
+            $column = $table->addColumn($columnName, $typeName, $options);
+            $this->write("Added column {$columnName} for table {$table->getName()}");
+        } else {
+            $column = $table->getColumn($columnName);
+            $this->write("Column {$columnName} for table {$table->getName()} already exists");
+        }
+        return $column;
+    }
+
+    /**
+     * @throws SchemaException
+     */
+    protected function addIndexedColumn(Table $table, string $columnName, string $typeName, array $options = []): Column
+    {
+        $column = $this->addColumn($table, $columnName, $typeName, $options);
+        $table->hasIndex($columnName) or $table->addIndex([$columnName], $columnName);
+        return $column;
+    }
+
+    protected function dropColumn(Table $table, string $columnName): void
+    {
+        if (!$table->hasColumn($columnName)) {
+            $this->write("Column {$columnName} for table layer already gone");
+            return;
+        }
+        $table->dropColumn($columnName);
+        $this->write("Dropped column {$columnName} from table layer");
+    }
+
+    /**
+     * @throws SchemaException
+     */
+    protected function dropIndexedColumn(Table $table, string $columnName): void
+    {
+        !$table->hasIndex($columnName) or $table->dropIndex($columnName);
+        $this->dropColumn($table, $columnName);
     }
 
     abstract protected function getDatabaseType(): ?MSPDatabaseType;

--- a/src/Domain/Common/Enum.php
+++ b/src/Domain/Common/Enum.php
@@ -17,8 +17,8 @@ abstract class Enum
     public function __construct($value)
     {
         assert(
-            in_array($value, $this->getConstants()),
-            'invalid value: ' . $value . ', possible values: ' . implode(',', $this->getConstants())
+            in_array($value, self::getConstants()),
+            'invalid value: ' . $value . ', possible values: ' . implode(',', self::getConstants())
         );
         $this->value = $value;
     }

--- a/src/Domain/Common/GetConstantsTrait.php
+++ b/src/Domain/Common/GetConstantsTrait.php
@@ -6,7 +6,7 @@ use ReflectionClass;
 
 trait GetConstantsTrait
 {
-    public function getConstants()
+    public static function getConstants(): array
     {
         $class = new ReflectionClass(get_called_class());
         return $class->getConstants();

--- a/src/Domain/Helper/Config.php
+++ b/src/Domain/Helper/Config.php
@@ -18,24 +18,30 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-//if you are ever questioning if your classes are being included, uncomment the line above and the words "config included" should show at the top of your page.
-class Config {
-	public static function get($path = null){
-		if($path){
-			$config = $GLOBALS['config'];
-			$path = explode('/', $path);
+//if you are ever questioning if your classes are being included, uncomment the line above and the words
+//  "config included" should show at the top of your page.
 
-			foreach ($path as $bit) {
-				if(isset($config[$bit])){
-					$config = $config[$bit];
-				} else {
-					return false;
-				}
-			}
+namespace App\Domain\Helper;
 
-			return $config;
-		}
+class Config
+{
+    public static function get($path = null)
+    {
+        if ($path) {
+            $config = $GLOBALS['config'];
+            $path = explode('/', $path);
 
-		return false;
-	}
+            foreach ($path as $bit) {
+                if (isset($config[$bit])) {
+                    $config = $config[$bit];
+                } else {
+                    return false;
+                }
+            }
+
+            return $config;
+        }
+
+        return false;
+    }
 }

--- a/src/Domain/WsServer/WsServerInterface.php
+++ b/src/Domain/WsServer/WsServerInterface.php
@@ -7,6 +7,8 @@ use React\EventLoop\LoopInterface;
 
 interface WsServerInterface
 {
+    public function getId(): string;
+    public function setId(?string $id): self;
     public function registerLoop(LoopInterface $loop);
     public function registerPlugin(PluginInterface $plugin): self;
     public function unregisterPlugin(PluginInterface $plugin);


### PR DESCRIPTION
demo of this fix:
[one drive video](https://edubuas-my.sharepoint.com/:v:/g/personal/hekman_m_buas_nl/EQyL3nJ9of5AokpFDU2jP9MBNrOq5HOTRTgdkZD8170-nA?e=dQMJ1y)
how it looks like after the demo in the database api_batch table:
![image](https://user-images.githubusercontent.com/89514754/172561946-413c48b6-d87e-4d8d-b30f-fcb0d576c99b.png)

* Moved Config.php from ServerManager/classes to src/Domain/Helper such that it can be used from the websocket server as well as the server manager side
* Added websocket server id. It can be passed as a console argument, if not, the default would be the scheme+address+port.
* Implemented a doctrine migration file to add api_batch_server_id, api_batch_communicated columns to api_batch table.
* Pass the websocket server id to Batch::executeNextQueuedBatchFor and ::executeQueuedBatch call such that it can be stored in the database to api_batch.api_batch_server_id
* After an executed batch, either failed or succeeded, the result still needs to be communicated to the client, after which now we call Batch::setCommunicated which writes "true" to the databases to api_batch.api_batch_communicated. Just so we can track it. There is no logic on this for now
* Extended the ExecuteBatchesWsServerPlugin, on first startup, e.g. after a crash, to check if there are any batches being executed that belong to this server (by matching the ids). If so, it will set them to Failed and communicate to the corresponding client if any.
* Added some base logic to MSPMigration. It will output the number of tables, columns and indexes added or dropped automatically. Also which columns were added or dropped, or where already existing. This can be extended for tables and indexes later. This is of course, to prevent code duplication on the implementation of a doctrine migration file, which define a class that extend on this MSPMigration
* Moved getWsServerURLBySessionId from ServerManager to WsServer . ServerManager::getWsServerURLBySessionId still exists but just calls WsServer::getWsServerURLBySessionId
* made getConstants in GetConstantsTrait static

next to this a fix on the server side, it would be nice to have like a large time-out on the client side where it will decide to fail the request itself. This would be the case when there is no web socket server running at all for instance.

we could lower the 10 sec waiting time on the client connection, but I think 10 sec is safer when we have a session with a lot of clients. Or the crash recovery mechanism would need to be improved - maybe later - like doing a crash recovery for each new client connection after the first start of the server. Then , we would not have this timing dependency....be of course, this is more complex implementation. I think this is good enough for beta 10. Note that the plugin system does have event information like client connection available, so it can certainly be done