### PR TITLE
run a migrations on websocket server start

### DIFF
--- a/bin/migrations
+++ b/bin/migrations
@@ -7,58 +7,16 @@ $projectDir = __DIR__ . '/..';
 require_once $projectDir . '/vendor/autoload.php';
 
 use App\Domain\Services\ConnectionManager;
-use Doctrine\Migrations\Configuration\Configuration;
-use Doctrine\Migrations\Configuration\Connection\ConnectionRegistryConnection;
-use Doctrine\Migrations\Configuration\Migration\ExistingConfiguration;
-use Doctrine\Migrations\DependencyFactory;
-use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
+use App\Domain\Services\DoctrineMigrationsDependencyFactoryHelper;
 use Doctrine\Migrations\Tools\Console\Command;
 use Doctrine\Migrations\Tools\Console\ConsoleLogger;
-use Doctrine\Persistence\AbstractManagerRegistry;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 $connectionManager = new ConnectionManager();
-$dbNames = $connectionManager->getDbNames();
-$configuration = new Configuration();
-$connectionRegistry = new class(
-    'msp_connection_registry',
-    array_combine($dbNames, $dbNames),
-    [], // entity managers
-    $connectionManager->getServerManagerDbName(), // default connection
-    'default', // default entity manager
-    'Doctrine\Persistence\Proxy' // proxy class
-) extends AbstractManagerRegistry {
-    // implement abstract methods here
-    protected function getService(string $name)
-    {
-        return ConnectionManager::getInstance()->getCachedDbConnection($name);
-    }
-
-    protected function resetService(string $name)
-    {
-        return ConnectionManager::getInstance()->getCachedDbConnection($name);
-    }
-};
-
-$migrationsDir = $projectDir . '/migrations';
-$configuration->addMigrationsDirectory('DoctrineMigrations', $migrationsDir);
-$configuration->setAllOrNothing(true);
-$configuration->setCheckDatabasePlatform(false);
-$configuration->setCustomTemplate($migrationsDir . '/template/template.tpl');
-
-$storageConfiguration = new TableMetadataStorageConfiguration();
-$storageConfiguration->setTableName('doctrine_migration_versions');
-
-$configuration->setMetadataStorageConfiguration($storageConfiguration);
-
-$configurationLoader = new ExistingConfiguration($configuration);
-$connectionLoader = ConnectionRegistryConnection::withSimpleDefault($connectionRegistry);
-$dependencyFactory = DependencyFactory::fromConnection(
-    $configurationLoader,
-    $connectionLoader
-);
+$dependencyFactoryHelper = new DoctrineMigrationsDependencyFactoryHelper($projectDir, $connectionManager);
+$dependencyFactory = $dependencyFactoryHelper->getDependencyFactory();
 
 // set logger
 $output = new ConsoleOutput();
@@ -68,7 +26,7 @@ $dependencyFactory->setService(LoggerInterface::class, $logger);
 $cli = new Application(
     'Doctrine Migrations for MSP Challenge' . PHP_EOL .
     'Please note that you can set a connection using "--conn". E.g. --conn=msp_session_1' . PHP_EOL .
-    'Use any of these connections: ' . implode(', ', $dbNames)
+    'Use any of these connections: ' . implode(', ', $connectionManager->getDbNames())
 );
 $cli->setCatchExceptions(true);
 $cli->addCommands(array(

--- a/src/Command/WsServerCommand.php
+++ b/src/Command/WsServerCommand.php
@@ -3,10 +3,7 @@
 namespace App\Command;
 
 use App\Domain\Services\SymfonyToLegacyHelper;
-use App\Domain\WsServer\Plugins\ExecuteBatchesWsServerPlugin;
-use App\Domain\WsServer\Plugins\Latest\LatestWsServerPlugin;
-use App\Domain\WsServer\Plugins\LoopStatsWsServerPlugin;
-use App\Domain\WsServer\Plugins\Tick\TicksHandlerWsServerPlugin;
+use App\Domain\WsServer\Plugins\BootstrapWsServerPlugin;
 use App\Domain\WsServer\WsServer;
 use App\Domain\WsServer\WsServerConsoleHelper;
 use App\Domain\WsServer\WsServerDebugOutput;
@@ -136,10 +133,7 @@ class WsServerCommand extends Command
         $this->wsServer->registerLoop($server->loop);
 
         // plugins
-        $this->wsServer->registerPlugin(new LoopStatsWsServerPlugin());
-        $this->wsServer->registerPlugin(new TicksHandlerWsServerPlugin());
-        $this->wsServer->registerPlugin(new LatestWsServerPlugin());
-        $this->wsServer->registerPlugin(new ExecuteBatchesWsServerPlugin());
+        $this->wsServer->registerPlugin(new BootstrapWsServerPlugin());
 
         sapi_windows_set_ctrl_handler(function (int $event) use ($server) {
             switch ($event) {

--- a/src/Domain/Services/DoctrineMigrationsDependencyFactoryHelper.php
+++ b/src/Domain/Services/DoctrineMigrationsDependencyFactoryHelper.php
@@ -34,7 +34,10 @@ class DoctrineMigrationsDependencyFactoryHelper
             }
             $dbNames = [$dbNameFilter];
         }
-        $defaultDbName = $dbNameFilter ?? $this->connectionManager->getServerManagerDbName();
+        $defaultDbName = $dbNameFilter ??
+            // try to use a msp_session_X database if any
+            (current(array_diff($dbNames, [$this->connectionManager->getServerManagerDbName()])) ?:
+            $this->connectionManager->getServerManagerDbName());
         $configuration = new Configuration();
         $connectionRegistry = new class(
             'msp_connection_registry',

--- a/src/Domain/Services/DoctrineMigrationsDependencyFactoryHelper.php
+++ b/src/Domain/Services/DoctrineMigrationsDependencyFactoryHelper.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Domain\Services;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\Configuration\Connection\ConnectionRegistryConnection;
+use Doctrine\Migrations\Configuration\Migration\ExistingConfiguration;
+use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
+use Doctrine\Persistence\AbstractManagerRegistry;
+
+class DoctrineMigrationsDependencyFactoryHelper
+{
+    private string $projectDir;
+    private ConnectionManager $connectionManager;
+
+    public function __construct(string $projectDir, ConnectionManager $connectionManager)
+    {
+        $this->projectDir = $projectDir;
+        $this->connectionManager = $connectionManager;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getDependencyFactory(?string $dbNameFilter = null): DependencyFactory
+    {
+        $dbNames = $this->connectionManager->getDbNames();
+        if (null !== $dbNameFilter) {
+            if (!in_array($dbNameFilter, $dbNames)) {
+                throw new Exception('Encountered non-existing database: '. $dbNameFilter);
+            }
+            $dbNames = [$dbNameFilter];
+        }
+        $defaultDbName = $dbNameFilter ?? $this->connectionManager->getServerManagerDbName();
+        $configuration = new Configuration();
+        $connectionRegistry = new class(
+            'msp_connection_registry',
+            array_combine($dbNames, $dbNames),
+            [], // entity managers
+            $defaultDbName, // default connection
+            'default', // default entity manager
+            'Doctrine\Persistence\Proxy' // proxy class
+        ) extends AbstractManagerRegistry {
+            // implement abstract methods here
+            protected function getService(string $name): Connection
+            {
+                return ConnectionManager::getInstance()->getCachedDbConnection($name);
+            }
+
+            protected function resetService(string $name): Connection
+            {
+                return ConnectionManager::getInstance()->getCachedDbConnection($name);
+            }
+        };
+
+        $migrationsDir = $this->projectDir . '/migrations';
+        $configuration->addMigrationsDirectory('DoctrineMigrations', $migrationsDir);
+        $configuration->setAllOrNothing(true);
+        $configuration->setCheckDatabasePlatform(false);
+        $configuration->setCustomTemplate($migrationsDir . '/template/template.tpl');
+
+        $storageConfiguration = new TableMetadataStorageConfiguration();
+        $storageConfiguration->setTableName('doctrine_migration_versions');
+
+        $configuration->setMetadataStorageConfiguration($storageConfiguration);
+
+        $configurationLoader = new ExistingConfiguration($configuration);
+        $connectionLoader = ConnectionRegistryConnection::withSimpleDefault($connectionRegistry);
+        return DependencyFactory::fromConnection(
+            $configurationLoader,
+            $connectionLoader
+        );
+    }
+}

--- a/src/Domain/WsServer/Plugins/BootstrapWsServerPlugin.php
+++ b/src/Domain/WsServer/Plugins/BootstrapWsServerPlugin.php
@@ -48,6 +48,7 @@ class BootstrapWsServerPlugin extends Plugin
      */
     private function migrations(array $gameSessionIds): void
     {
+        echo 'Please do not shut down the websocket server now, until migrations are finished...' . PHP_EOL;
         // Run doctrine migrations.
         foreach ($gameSessionIds as $gameSessionId) {
             $dbName = ConnectionManager::getInstance()->getGameSessionDbName($gameSessionId);
@@ -69,7 +70,9 @@ class BootstrapWsServerPlugin extends Plugin
                     $returnCode
                 );
             }
+            echo $output->fetch();
         }
+        echo 'Finished migrations' . PHP_EOL;
     }
 
     private function registerPlugins(): void

--- a/src/Domain/WsServer/Plugins/BootstrapWsServerPlugin.php
+++ b/src/Domain/WsServer/Plugins/BootstrapWsServerPlugin.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Domain\WsServer\Plugins;
+
+use App\Domain\Services\ConnectionManager;
+use App\Domain\Services\SymfonyToLegacyHelper;
+use App\Domain\WsServer\Plugins\Latest\LatestWsServerPlugin;
+use App\Domain\WsServer\Plugins\Tick\TicksHandlerWsServerPlugin;
+use Closure;
+use Drift\DBAL\Result;
+use Exception;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class BootstrapWsServerPlugin extends Plugin
+{
+    public function __construct()
+    {
+        parent::__construct('bootstrap', 0); // 0 meaning no interval, no repeating
+    }
+
+    protected function onCreatePromiseFunction(): Closure
+    {
+        return function () {
+            return $this->getServerManager()->getGameSessionIds()
+                ->then(function (Result $result) {
+                    // collect
+                    $gameSessionIds = collect($result->fetchAllRows() ?? [])
+                        ->keyBy('id')
+                        ->map(function ($row) {
+                            return $row['id'];
+                        });
+                    $gameSessionId = $this->getGameSessionIdFilter();
+                    if ($gameSessionId != null) {
+                        $gameSessionIds = $gameSessionIds->only($gameSessionId);
+                    }
+                    $gameSessionIds = $gameSessionIds->all(); // to raw array
+
+                    $this->migrations($gameSessionIds);
+                    $this->registerPlugins();
+                });
+        };
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function migrations(array $gameSessionIds): void
+    {
+        // Run doctrine migrations.
+        foreach ($gameSessionIds as $gameSessionId) {
+            $dbName = ConnectionManager::getInstance()->getGameSessionDbName($gameSessionId);
+            if ($this->getServerManager()->getDoctrineMigrationsDependencyFactoryHelper()
+                ->getDependencyFactory($dbName)->getMigrationStatusCalculator()->getNewMigrations()->count() == 0) {
+                // nothing to migrate
+                continue;
+            }
+            $application = new Application(SymfonyToLegacyHelper::getInstance()->getKernel());
+            $application->setAutoExit(false);
+            $output = new BufferedOutput();
+            $returnCode = $application->run(
+                new StringInput('doctrine:migrations:migrate -vvv -n --conn=' . $dbName),
+                $output
+            );
+            if (0 !== $returnCode) {
+                throw new Exception(
+                    'Failed to apply newest migrations to database: ' . $dbName . PHP_EOL . $output->fetch(),
+                    $returnCode
+                );
+            }
+        }
+    }
+
+    private function registerPlugins(): void
+    {
+        $this->getWsServer()->registerPlugin(new LoopStatsWsServerPlugin());
+        $this->getWsServer()->registerPlugin(new TicksHandlerWsServerPlugin());
+        $this->getWsServer()->registerPlugin(new LatestWsServerPlugin());
+        $this->getWsServer()->registerPlugin(new ExecuteBatchesWsServerPlugin());
+    }
+}

--- a/src/Domain/WsServer/Plugins/Plugin.php
+++ b/src/Domain/WsServer/Plugins/Plugin.php
@@ -72,6 +72,12 @@ abstract class Plugin implements PluginInterface
     {
         $this->registeredToLoop = true;
         $this->loop = $loop;
+
+        // interval sec is zero, so no interval, no repeating
+        if ($this->getMinIntervalSec() < PHP_FLOAT_EPSILON) {
+            $loop->futureTick($this->onCreatePromiseFunction());
+            return;
+        }
         $loop->addTimer(mt_rand() * $this->getMinIntervalSec() / mt_getrandmax(), PluginHelper::createRepeatedFunction(
             $this,
             $loop,

--- a/src/Domain/WsServer/ServerManagerInterface.php
+++ b/src/Domain/WsServer/ServerManagerInterface.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\WsServer;
 
+use App\Domain\Services\DoctrineMigrationsDependencyFactoryHelper;
 use Drift\DBAL\Connection;
 use React\Promise\PromiseInterface;
 
@@ -10,4 +11,5 @@ interface ServerManagerInterface
     public function getGameSessionIds(bool $onlyPlaying = false): PromiseInterface;
     public function getGameSessionDbConnection(int $gameSessionId): Connection;
     public function getServerManagerDbConnection(): Connection;
+    public function getDoctrineMigrationsDependencyFactoryHelper(): DoctrineMigrationsDependencyFactoryHelper;
 }

--- a/src/Domain/WsServer/WsServer.php
+++ b/src/Domain/WsServer/WsServer.php
@@ -5,6 +5,7 @@ use App\Domain\API\v1\Security;
 use App\Domain\Event\NameAwareEvent;
 use App\Domain\Helper\Util;
 use App\Domain\Services\ConnectionManager;
+use App\Domain\Services\DoctrineMigrationsDependencyFactoryHelper;
 use App\Domain\WsServer\Plugins\PluginInterface;
 use Drift\DBAL\Connection;
 use Exception;
@@ -54,15 +55,25 @@ class WsServer extends EventDispatcher implements
      */
     private array $pluginsUnregistered = [];
 
+    private DoctrineMigrationsDependencyFactoryHelper $doctrineMigrationsDependencyFactoryHelper;
+
+    public function getDoctrineMigrationsDependencyFactoryHelper(): DoctrineMigrationsDependencyFactoryHelper
+    {
+        return $this->doctrineMigrationsDependencyFactoryHelper;
+    }
+
     public function getStats(): array
     {
         return $this->stats;
     }
 
     public function __construct(
+        DoctrineMigrationsDependencyFactoryHelper $doctrineMigrationsDependencyFactoryHelper,
         // below is required by legacy to be auto-wired
         \App\Domain\API\APIHelper $apiHelper
     ) {
+        $this->doctrineMigrationsDependencyFactoryHelper = $doctrineMigrationsDependencyFactoryHelper;
+
         // for backwards compatibility, to prevent missing request data errors
         $_SERVER['REQUEST_URI'] = '';
 


### PR DESCRIPTION
* added new BootstrapWsServerPlugin for the websocket server, which:
  - detect the need for database migrations, and applies them;
  - after the migrations if will register the other plugins: tick, latest etc
* created a service DoctrineMigrationsDependencyFactoryHelper which is used by both the  console bin/migrations and by BootstrapWsServerPlugin
* Extend Plugin class to allow zero value for minIntervalSec, in which case it will only run the plugin once (no interval)