### PR TITLE
fixed output verbosity

### DIFF
--- a/src/Domain/WsServer/Plugins/AwaitPrerequisitesWsServerPlugin.php
+++ b/src/Domain/WsServer/Plugins/AwaitPrerequisitesWsServerPlugin.php
@@ -5,6 +5,7 @@ namespace App\Domain\WsServer\Plugins;
 use App\Domain\Event\NameAwareEvent;
 use Closure;
 use React\Promise\PromiseInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class AwaitPrerequisitesWsServerPlugin extends Plugin
 {
@@ -13,6 +14,7 @@ class AwaitPrerequisitesWsServerPlugin extends Plugin
     public function __construct()
     {
         parent::__construct('bootstrap', 10);
+        $this->setMessageVerbosity(OutputInterface::VERBOSITY_NORMAL);
     }
 
     private function checkServerManagerDbConnection(): PromiseInterface
@@ -26,12 +28,12 @@ class AwaitPrerequisitesWsServerPlugin extends Plugin
                 ->setMaxResults(1)
         )
         ->then(function (/* Result $resul t*/) {
-            wdo('Found msp_server_manager database');
+            $this->addOutput('Found msp_server_manager database');
             $this->dispatch(new NameAwareEvent(self::EVENT_PREREQUISITES_MET), self::EVENT_PREREQUISITES_MET);
         })
         ->otherwise(function ($reason) {
             // Handle the rejection, and don't propagate. This is like catch without a rethrow
-            wdo('Awaiting creation of msp_server_manager database');
+            $this->addOutput('Awaiting creation of msp_server_manager database');
             return null;
         });
     }

--- a/src/Domain/WsServer/Plugins/BootstrapWsServerPlugin.php
+++ b/src/Domain/WsServer/Plugins/BootstrapWsServerPlugin.php
@@ -7,6 +7,7 @@ use App\Domain\WsServer\Plugins\Latest\LatestWsServerPlugin;
 use App\Domain\WsServer\Plugins\Tick\TicksHandlerWsServerPlugin;
 use Closure;
 use Exception;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class BootstrapWsServerPlugin extends Plugin implements EventSubscriberInterface
@@ -24,6 +25,7 @@ class BootstrapWsServerPlugin extends Plugin implements EventSubscriberInterface
     public function __construct()
     {
         parent::__construct('bootstrap', 0); // 0 meaning no interval, no repeating
+        $this->setMessageVerbosity(OutputInterface::VERBOSITY_NORMAL);
         $this->awaitPrerequisitesPlugin = $this->createAwaitPrerequisitesPlugin();
         $this->databaseMigrationsPlugin = $this->createDatabaseMigrationsPlugin();
     }
@@ -64,7 +66,7 @@ class BootstrapWsServerPlugin extends Plugin implements EventSubscriberInterface
                 $this->startStateRegisterPlugins();
                 break;
             case self::STATE_READY:
-                wdo('Websocket server is ready');
+                $this->addOutput('Websocket server is ready');
                 break;
         }
     }

--- a/src/Domain/WsServer/Plugins/DatabaseMigrationsWsServerPlugin.php
+++ b/src/Domain/WsServer/Plugins/DatabaseMigrationsWsServerPlugin.php
@@ -11,6 +11,7 @@ use Exception;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class DatabaseMigrationsWsServerPlugin extends Plugin
 {
@@ -19,6 +20,7 @@ class DatabaseMigrationsWsServerPlugin extends Plugin
     public function __construct()
     {
         parent::__construct('migrations', 0);
+        $this->setMessageVerbosity(OutputInterface::VERBOSITY_NORMAL);
     }
 
     protected function onCreatePromiseFunction(): Closure
@@ -52,7 +54,7 @@ class DatabaseMigrationsWsServerPlugin extends Plugin
      */
     private function migrations(array $gameSessionIds): void
     {
-        wdo('Please do not shut down the websocket server now, until migrations are finished...');
+        $this->addOutput('Please do not shut down the websocket server now, until migrations are finished...');
         // Run doctrine migrations.
         foreach ($gameSessionIds as $gameSessionId) {
             $dbName = ConnectionManager::getInstance()->getGameSessionDbName($gameSessionId);
@@ -74,8 +76,8 @@ class DatabaseMigrationsWsServerPlugin extends Plugin
                     $returnCode
                 );
             }
-            wdo($output->fetch());
+            $this->addOutput($output->fetch());
         }
-        wdo('Finished migrations');
+        $this->addOutput('Finished migrations');
     }
 }

--- a/src/Domain/WsServer/Plugins/ExecuteBatchesWsServerPlugin.php
+++ b/src/Domain/WsServer/Plugins/ExecuteBatchesWsServerPlugin.php
@@ -57,10 +57,7 @@ class ExecuteBatchesWsServerPlugin extends Plugin
                     if (empty($clientToBatchResultContainer)) {
                         return;
                     }
-                    $this->addOutput(
-                        json_encode($clientToBatchResultContainer),
-                        OutputInterface::VERBOSITY_VERY_VERBOSE
-                    );
+                    $this->addOutput(json_encode($clientToBatchResultContainer));
                 })
                 ->otherwise(function ($reason) {
                     if ($reason instanceof ClientDisconnectedException) {
@@ -113,7 +110,10 @@ class ExecuteBatchesWsServerPlugin extends Plugin
         foreach ($clientInfoPerSessionContainer as $clientInfoContainer) {
             foreach ($clientInfoContainer as $connResourceId => $clientInfo) {
                 $timeStart = microtime(true);
-                $this->addOutput('Starting "executeBatches" for: ' . $connResourceId);
+                $this->addOutput(
+                    'Starting "executeBatches" for: ' . $connResourceId,
+                    OutputInterface::VERBOSITY_VERY_VERBOSE
+                );
                 $promises[$connResourceId] = $this->getBatch($connResourceId)
                     ->executeNextQueuedBatchFor(
                         $clientInfo['team_id'],
@@ -122,7 +122,10 @@ class ExecuteBatchesWsServerPlugin extends Plugin
                     )
                 ->then(
                     function (array $batchResultContainer) use ($connResourceId, $timeStart, $clientInfo) {
-                        $this->addOutput('Created "executeBatches" payload for: ' . $connResourceId);
+                        $this->addOutput(
+                            'Created "executeBatches" payload for: ' . $connResourceId,
+                            OutputInterface::VERBOSITY_VERY_VERBOSE
+                        );
                         $this->getClientConnectionResourceManager()->addToMeasurementCollection(
                             $this->getName(),
                             $connResourceId,

--- a/src/Domain/WsServer/Plugins/Latest/GameLatest.php
+++ b/src/Domain/WsServer/Plugins/Latest/GameLatest.php
@@ -7,6 +7,7 @@ use Drift\DBAL\Result;
 use Exception;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use function App\parallel;
 use function App\tpf;
 
@@ -220,26 +221,26 @@ class GameLatest extends CommonBase
                         }
 
                         if ($showDebug) {
-                            wdo("diff: " . $diff);
+                            wdo("diff: " . $diff, OutputInterface::VERBOSITY_VERY_VERBOSE);
                         }
 
                         if ($showDebug) {
-                            wdo("timeleft: " . $tick['era_timeleft']);
+                            wdo("timeleft: " . $tick['era_timeleft'], OutputInterface::VERBOSITY_VERY_VERBOSE);
                         }
                     } elseif ($state == "PAUSE" || $state == "SETUP") {
                         //[MSP-1116] Seems sensible?
                         $tick['era_timeleft'] = $tick['era_realtime'] - ($tick['era_monthsdone'] * $secondsPerMonth);
                         if ($showDebug) {
-                            wdo('GAME PAUSED');
+                            wdo('GAME PAUSED', OutputInterface::VERBOSITY_VERY_VERBOSE);
                         }
                     } else {
                         if ($showDebug) {
-                            wdo('GAME ENDED');
+                            wdo('GAME ENDED', OutputInterface::VERBOSITY_VERY_VERBOSE);
                         }
                     }
 
                     if ($showDebug) {
-                        wdo(json_encode($tick));
+                        wdo('Tick: ' . PHP_EOL . json_encode($tick));
                     }
 
                     return $tick;

--- a/src/Domain/WsServer/Plugins/Latest/LatestWsServerPlugin.php
+++ b/src/Domain/WsServer/Plugins/Latest/LatestWsServerPlugin.php
@@ -44,7 +44,7 @@ class LatestWsServerPlugin extends Plugin
                     if (empty($payloadContainer)) {
                         return;
                     }
-                    $this->addOutput(json_encode($payloadContainer), OutputInterface::VERBOSITY_VERY_VERBOSE);
+                    $this->addOutput(json_encode($payloadContainer));
                 })
                 ->otherwise(function ($reason) {
                     if ($reason instanceof ClientDisconnectedException) {
@@ -78,14 +78,12 @@ class LatestWsServerPlugin extends Plugin
                     ]
                 )) {
                     // Client's token has been expired, let the client re-connected with a new token
-                    $this->addOutput(
-                        'Client\'s token has been expired, let the client re-connected with a new token'
-                    );
+                    $this->addOutput('Client\'s token has been expired, let the client re-connected with a new token');
                     $this->getClientConnectionResourceManager()->getClientConnection($connResourceId)->close();
                     continue;
                 }
                 $latestTimeStart = microtime(true);
-                $this->addOutput('Starting "latest" for: ' . $connResourceId);
+                $this->addOutput('Starting "latest" for: ' . $connResourceId, OutputInterface::VERBOSITY_VERY_VERBOSE);
                 $promises[$connResourceId] = $this->getGameLatest($connResourceId)->Latest(
                     $clientInfo['team_id'],
                     $clientInfo['last_update_time'],
@@ -93,14 +91,17 @@ class LatestWsServerPlugin extends Plugin
                     $this->isDebugOutputEnabled()
                 )
                 ->then(function ($payload) use ($connResourceId, $latestTimeStart, $clientInfo) {
-                    $this->addOutput('Created "latest" payload for: ' . $connResourceId);
+                    $this->addOutput(
+                        'Created "latest" payload for: ' . $connResourceId,
+                        OutputInterface::VERBOSITY_VERY_VERBOSE
+                    );
                     $this->getMeasurementCollectionManager()->addToMeasurementCollection(
                         $this->getName(),
                         $connResourceId,
                         microtime(true) - $latestTimeStart
                     );
                     if (empty($payload)) {
-                        $this->addOutput('empty payload');
+                        $this->addOutput('empty payload', OutputInterface::VERBOSITY_VERY_VERBOSE);
                         return [];
                     }
                     if (null === $this->getClientConnectionResourceManager()->getClientConnection($connResourceId)) {
@@ -136,7 +137,8 @@ class LatestWsServerPlugin extends Plugin
                         // no essential payload differences compared to the previous one, no need to send it now
                         $this->addOutput(
                             'no essential payload differences compared to the previous one, ' .
-                            'no need to send it now'
+                                'no need to send it now',
+                            OutputInterface::VERBOSITY_VERY_VERBOSE
                         );
                         return []; // no need to send
                     }

--- a/src/Domain/WsServer/Plugins/Plugin.php
+++ b/src/Domain/WsServer/Plugins/Plugin.php
@@ -6,11 +6,11 @@ use App\Domain\WsServer\ClientConnectionResourceManagerInterface;
 use App\Domain\WsServer\MeasurementCollectionManagerInterface;
 use App\Domain\WsServer\ServerManagerInterface;
 use App\Domain\WsServer\WsServerInterface;
+use App\Domain\WsServer\WsServerOutput;
 use Exception;
 use React\EventLoop\LoopInterface;
 use Closure;
 use App\Domain\Event\NameAwareEvent;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 abstract class Plugin extends EventDispatcher implements PluginInterface
@@ -18,6 +18,7 @@ abstract class Plugin extends EventDispatcher implements PluginInterface
     private string $name;
     private float $minIntervalSec;
     private bool $debugOutputEnabled;
+    private int $messageVerbosity = WsServerOutput::VERBOSITY_DEFAULT_MESSAGE;
     private ?int $gameSessionIdFilter = null;
     private bool $registeredToLoop = false;
 
@@ -58,8 +59,19 @@ abstract class Plugin extends EventDispatcher implements PluginInterface
         $this->debugOutputEnabled = $debugOutputEnabled;
     }
 
-    public function addOutput(string $output, int $verbosity = OutputInterface::VERBOSITY_NORMAL): self
+    public function getMessageVerbosity(): int
     {
+        return $this->messageVerbosity;
+    }
+
+    public function setMessageVerbosity(int $messageVerbosity): void
+    {
+        $this->messageVerbosity = $messageVerbosity;
+    }
+
+    public function addOutput(string $output, ?int $verbosity = null): self
+    {
+        $verbosity ??= $this->messageVerbosity;
         if ($this->isDebugOutputEnabled()) {
             wdo($output, $verbosity);
         }

--- a/src/Domain/WsServer/Plugins/PluginHelper.php
+++ b/src/Domain/WsServer/Plugins/PluginHelper.php
@@ -39,7 +39,7 @@ class PluginHelper
             if (!$plugin->isRegisteredToLoop()) {
                 $plugin->addOutput(
                     'Unregistered from loop: "' . $plugin->getName() .'"',
-                    OutputInterface::VERBOSITY_VERBOSE
+                    OutputInterface::VERBOSITY_VERY_VERBOSE
                 );
                 return;
             }

--- a/src/Domain/WsServer/Plugins/Tick/GameTick.php
+++ b/src/Domain/WsServer/Plugins/Tick/GameTick.php
@@ -12,6 +12,7 @@ use App\SilentFailException;
 use Drift\DBAL\Result;
 use Exception;
 use React\Promise\PromiseInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class GameTick extends TickBase
 {
@@ -88,20 +89,23 @@ class GameTick extends TickBase
             ($tickData['era_realtime'] / $tickData['era_gametime']);
         if ($diff <= $secondsPerMonth) {
             if ($showDebug) {
-                wdo("Waiting for update time " . ($secondsPerMonth - $diff) . " seconds remaining");
+                wdo(
+                    "Waiting for update time " . ($secondsPerMonth - $diff) . " seconds remaining",
+                    OutputInterface::VERBOSITY_VERY_VERBOSE
+                );
             }
             return null;
         }
 
         // let's do the "tick" which updates server time and month
         if ($showDebug) {
-            wdo("Trying to tick the server");
+            wdo("Trying to tick the server", OutputInterface::VERBOSITY_VERY_VERBOSE);
         }
 
         if (!strstr($_SERVER['REQUEST_URI'], 'dev') || Config::GetInstance()->ShouldWaitForSimulationsInDev()) {
             if (!$this->AreSimulationsUpToDate($tickData)) {
                 if ($showDebug) {
-                    wdo('Waiting for simulations to update.');
+                    wdo('Waiting for simulations to update.', OutputInterface::VERBOSITY_VERY_VERBOSE);
                 }
                 return null;
             }
@@ -168,7 +172,7 @@ class GameTick extends TickBase
     private function serverTickInternal(bool $showDebug): PromiseInterface
     {
         if ($showDebug) {
-            wdo('Ticking server.');
+            wdo('Ticking server.', OutputInterface::VERBOSITY_VERY_VERBOSE);
         }
         return $this->getAsyncDatabase()->query(
             $this->getAsyncDatabase()->createQueryBuilder()

--- a/src/Domain/WsServer/Plugins/Tick/TickWsServerPlugin.php
+++ b/src/Domain/WsServer/Plugins/Tick/TickWsServerPlugin.php
@@ -49,7 +49,10 @@ class TickWsServerPlugin extends Plugin
             return resolveOnFutureTick(new Deferred(), $this->gameSessionId)->promise();
         }
 
-        $this->addOutput('starting "tick" for game session: ' . $this->gameSessionId);
+        $this->addOutput(
+            'starting "tick" for game session: ' . $this->gameSessionId,
+            OutputInterface::VERBOSITY_VERY_VERBOSE
+        );
         $tickTimeStart = microtime(true);
         return $this->getGameTick($this->gameSessionId)->Tick(
             $this->isDebugOutputEnabled()

--- a/src/Domain/WsServer/WsServerOutput.php
+++ b/src/Domain/WsServer/WsServerOutput.php
@@ -6,7 +6,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class WsServerOutput
 {
-    private const VERBOSITY_DEFAULT = OutputInterface::VERBOSITY_NORMAL;
+    public const VERBOSITY_DEFAULT_MESSAGE = OutputInterface::VERBOSITY_VERBOSE;
+    private const VERBOSITY_DEFAULT_OUTPUT = OutputInterface::VERBOSITY_NORMAL;
 
     private static ?int $verbosity = null;
     private static ?string $messageFilter = null;
@@ -16,12 +17,12 @@ class WsServerOutput
         if (self::$verbosity === null && array_key_exists('WS_SERVER_OUTPUT_VERBOSITY', $_ENV)) {
             self::$verbosity = (int)$_ENV['WS_SERVER_OUTPUT_VERBOSITY'];
         }
-        return self::$verbosity ?? self::VERBOSITY_DEFAULT;
+        return self::$verbosity ?? self::VERBOSITY_DEFAULT_OUTPUT;
     }
 
     public static function setVerbosity(int $verbosity): void
     {
-        if ($verbosity == self::VERBOSITY_DEFAULT) {
+        if ($verbosity == self::VERBOSITY_DEFAULT_OUTPUT) {
             return;
         }
         self::$verbosity = $verbosity;
@@ -32,7 +33,7 @@ class WsServerOutput
         self::$messageFilter = $messageFilter;
     }
 
-    public static function output(string $message, int $verbosity = OutputInterface::VERBOSITY_NORMAL): void
+    public static function output(string $message, int $verbosity = self::VERBOSITY_DEFAULT_MESSAGE): void
     {
         if ($verbosity > self::getVerbosity()) {
             return;

--- a/src/Domain/WsServer/functions.php
+++ b/src/Domain/WsServer/functions.php
@@ -1,11 +1,10 @@
 <?php
 
 use App\Domain\WsServer\WsServerOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 
 function wdo(
     string $message,
-    int $verbosity = OutputInterface::VERBOSITY_NORMAL
+    int $verbosity = WsServerOutput::VERBOSITY_DEFAULT_MESSAGE
 ) {
     WsServerOutput::output($message, $verbosity);
 }


### PR DESCRIPTION
normal level: (no arguments, the default)
- shows one-time messages like: migrating... server ready

verbose level: (-v or --verbose)
- shows all communications, like client connections, all content messages etc
(This will be mostly used on dev environments. You can set .env file with WS_SERVER_OUTPUT_VERBOSITY=64)

very verbose level: (-vv or -vvv)
- shows flows, like starting tick, finished tick, that kind. Any repetitive stuff

needed for beta10 such that it does not output so much by default

## Checklist before requesting a review
- [ ] I am using the Jira issue number in the commit message.
- [ ] The branch is named as the Jira issue number.
