### PR TITLE
MSP-4424 No more separate StartBatch/AddToBatch api calls. They have been merged towards ExecuteBatch api call.

### DIFF
--- a/api/v1/Batch.php
+++ b/api/v1/Batch.php
@@ -22,8 +22,6 @@ class Batch extends Base
     private array $cachedBatchResults = [];
 
     private const ALLOWED = array(
-        "StartBatch",
-        "AddToBatch",
         "ExecuteBatch"
     );
     
@@ -33,66 +31,49 @@ class Batch extends Base
     }
 
     /**
-     * @apiGroup Batch
      * @throws Exception
-     * @api {POST} /batch/startbatch StartBatch
-     * @apiDescription Starts a new batch
-     *
-     * @apiParam {int} $country_id id of country/team for which the batch was started
-     * @apiParam {int} $user_id id of user for which the batch was started
-     *
-     * @apiSuccess {int} batch_id Batch ID used to identify this batch.
-     * @noinspection PhpUnused
      */
-    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function StartBatch(int $country_id, int $user_id)
+    private function startBatch(int $countryId, int $userId, string $batchGuid): int
     {
-        return $this->getDatabase()->query(
-            "INSERT INTO api_batch(api_batch_country_id, api_batch_user_id) VALUES (?, ?)",
-            array($country_id, $user_id),
+        $id = $this->getDatabase()->query(
+            "INSERT INTO api_batch(api_batch_country_id, api_batch_user_id, api_batch_guid) VALUES (?, ?, ?)",
+            array($countryId, $userId, $batchGuid),
             true
         );
+        if (empty($id)) { // empty array (no connection), or false (insert failed)
+            return 0;
+        }
+        return (int)$id;
     }
 
     /**
-     * @apiGroup Batch
+     * @param int $batchId
+     * @param array{int: array{call_id: int, group: string, end_point: string, endpoint_data: string}} $requests
      * @throws Exception
-     * @api {POST} /batch/addtobatch AddToBatch
-     * @apiDescription Starts a new batch
-     *
-     * @apiParam {int} batch_id Batch ID to add to
-     * @apiParam {int} batch_group Batch execution group
-     * @apiParam {string} call_id Client defined identfier that is unique within the current batch_id.
-     * @apiParam {string} endpoint Endpoint for this batch call to make. E.g. "api/geometry/post"
-     * @apiParam {string} endpoint_data Json data that should be send to the endpoint when called.
-     *
-     * @apiSuccess {int} execution_task_id Unique task identifier used to identify this execution task.
-     * @noinspection PhpUnused
      */
-    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function AddToBatch(
-        int $batch_id,
-        int $batch_group,
-        string $call_id,
-        string $endpoint,
-        string $endpoint_data
-    ): string {
-        $endpoint = preg_replace("/\A[\/]?api\//", "", $endpoint);
-        
-        $this->getDatabase()->query("INSERT INTO api_batch_task (
-			api_batch_task_batch_id, 
-			api_batch_task_group, 
-			api_batch_task_reference_identifier, 
-			api_batch_task_api_endpoint, 
-			api_batch_task_api_endpoint_data)
-			VALUES (?, ?, ?, ?, ?)", array(
-                $batch_id,
-                $batch_group,
-                $call_id,
-                $endpoint,
-                $endpoint_data));
-        
-        return $call_id;
+    private function addToBatch(
+        int $batchId,
+        array $requests
+    ): void {
+        $requests = collect($requests)->map(function ($r) {
+            $r['endpoint'] = preg_replace("/\A[\/]?api\//", "", $r['endpoint']);
+            return $r;
+        })->all();
+        foreach ($requests as $r) {
+            $this->getDatabase()->query("INSERT INTO api_batch_task (
+                api_batch_task_batch_id, 
+                api_batch_task_group, 
+                api_batch_task_reference_identifier, 
+                api_batch_task_api_endpoint, 
+                api_batch_task_api_endpoint_data)
+                VALUES (?, ?, ?, ?, ?)", array(
+                    $batchId,
+                    $r['group'],
+                    $r['call_id'],
+                    $r['endpoint'],
+                    $r['endpoint_data']
+            ));
+        }
     }
 
     /**
@@ -101,7 +82,10 @@ class Batch extends Base
      * @api {POST} /batch/executebatch ExecuteBatch
      * @apiDescription execute batch
      *
-     * @apiParam {int} batch_id Batch ID to execute.
+     * @apiParam {int} $country_id id of country/team for which the batch was started
+     * @apiParam {int} $user_id id of user for which the batch was started
+     * @apiParam {string} batch_guid Batch Guid to execute.
+     * @apiParam {string} requests Json data containg the batch requests
      * @apiParam {bool} async Execute this batch asynchronous. Results of the executed batch will be communicated
      *   through the websocket connection.
      *
@@ -113,8 +97,21 @@ class Batch extends Base
      * @return array|string
      */
     // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function ExecuteBatch(int $batch_id, bool $async = false)/*: array|string // <-- php 8 */
-    {
+    public function ExecuteBatch(
+        int $country_id,
+        int $user_id,
+        string $batch_guid,
+        string $requests,
+        bool $async = false
+    ): array|string {
+        if (0 === $batchId = $this->startBatch($country_id, $user_id, $batch_guid)) {
+            throw new Exception("Unable to start batch: ".$batch_guid);
+        }
+        // @var null|array{int: array{call_id: int, group: string, end_point: string, endpoint_data: string}}
+        if (null === $requests = json_decode($requests, true)) {
+            throw new Exception("Unable to decode requests for batch: ".$batch_guid);
+        }
+        $this->addToBatch($batchId, $requests);
         if ($async) {
             $data = $this->getDatabase()->query("SELECT api_batch_task_id, 
                     api_batch_task_reference_identifier, 
@@ -122,7 +119,7 @@ class Batch extends Base
                     api_batch_task_api_endpoint_data 
                 FROM api_batch_task 
                 WHERE api_batch_task_batch_id = ? 
-                ORDER BY api_batch_task_group", array($batch_id));
+                ORDER BY api_batch_task_group", array($batchId));
             if (empty($data)) {
                 throw new Exception("Tried to execute an empty batch");
             }
@@ -130,7 +127,7 @@ class Batch extends Base
             // queue it
             $this->getDatabase()->query(
                 'UPDATE api_batch SET api_batch_state=\'Queued\' WHERE api_batch_id = ?',
-                array($batch_id)
+                array($batchId)
             );
 
             // no results yet, will be sent later through websocket connection
@@ -146,7 +143,7 @@ class Batch extends Base
 				api_batch_task_api_endpoint_data 
 			FROM api_batch_task 
 			WHERE api_batch_task_batch_id = ? 
-			ORDER BY api_batch_task_group", array($batch_id));
+			ORDER BY api_batch_task_group", array($batchId));
         if (empty($data)) {
             throw new Exception("Tried to execute an empty batch");
         }
@@ -191,7 +188,7 @@ class Batch extends Base
         $qb = $this->getAsyncDatabase()->createQueryBuilder();
         $this->getAsyncDatabase()->query(
             $qb
-                ->select('b.api_batch_id')
+                ->select('b.api_batch_guid')
                 ->from('api_batch', 'b')
                 ->where(
                     $qb->expr()->and(
@@ -207,10 +204,10 @@ class Batch extends Base
             if (null === $row = $result->fetchFirstRow()) {
                 return [];
             }
-            $batchId = $row['api_batch_id'];
-            return $this->executeQueuedBatch($batchId, $serverId)
-                ->otherwise(function ($reason) use ($batchId) {
-                    return reject(new ExecuteBatchRejection($batchId, $reason));
+            $batchGuid = $row['api_batch_guid'];
+            return $this->executeQueuedBatch($batchGuid, $serverId)
+                ->otherwise(function ($reason) use ($batchGuid) {
+                    return reject(new ExecuteBatchRejection($batchGuid, $reason));
                 });
         })
         ->done(
@@ -228,21 +225,21 @@ class Batch extends Base
     /**
      * @throws Exception
      */
-    public function setCommunicated(int $batchId): Promise
+    public function setCommunicated(string $batchGuid): Promise
     {
         $qb = $this->getAsyncDatabase()->createQueryBuilder();
         return $this->getAsyncDatabase()->query(
             $qb
                 ->update('api_batch')
                 ->set('api_batch_communicated', $qb->createPositionalParameter(true, Types::BOOLEAN))
-                ->where($qb->expr()->eq('api_batch_id', $batchId))
+                ->where($qb->expr()->eq('api_batch_guid', $qb->createPositionalParameter($batchGuid)))
         );
     }
 
-    public function executeQueuedBatch(int $batchId, string $serverId): Promise
+    public function executeQueuedBatch(string $batchGuid, string $serverId): Promise
     {
         // get batch tasks to execute
-        $this->cachedBatchResults[$batchId] = [];
+        $this->cachedBatchResults[$batchGuid] = [];
         $qb = $this->getAsyncDatabase()->createQueryBuilder();
         return query(
             $this->getAsyncDatabase(),
@@ -256,11 +253,11 @@ class Batch extends Base
                     $qb->expr()->and(
                         'b.api_batch_id = t.api_batch_task_batch_id',
                         'b.api_batch_state = "Queued"',
-                        $qb->expr()->eq('b.api_batch_id', $batchId)
+                        $qb->expr()->eq('b.api_batch_guid', $qb->createPositionalParameter($batchGuid))
                     )
                 )
         )
-        ->then(function (Result $result) use ($batchId, $serverId) {
+        ->then(function (Result $result) use ($batchGuid, $serverId) {
             $deferred = new Deferred();
             // first set the state to "Executing" before continuing
             $qb = $this->getAsyncDatabase()->createQueryBuilder();
@@ -269,20 +266,20 @@ class Batch extends Base
                     ->update('api_batch')
                     ->set('api_batch_server_id', $qb->createPositionalParameter($serverId))
                     ->set('api_batch_state', $qb->createPositionalParameter('Executing'))
-                    ->where($qb->expr()->eq('api_batch_id', $batchId))
+                    ->where($qb->expr()->eq('api_batch_guid', $qb->createPositionalParameter($batchGuid)))
             )
             ->done(
                 function (Result $dummy) use ($deferred, $result) {
                     // just pass the original result.
                     $deferred->resolve($result);
                 },
-                function () use ($deferred, $batchId) {
-                    $deferred->reject('Could not set to status "Executing" for batch id: ' . $batchId);
+                function () use ($deferred, $batchGuid) {
+                    $deferred->reject('Could not set to status "Executing" for batch guid: ' . $batchGuid);
                 }
             );
             return $deferred->promise();
         })
-        ->then(function (Result $result) use ($batchId) {
+        ->then(function (Result $result) use ($batchGuid) {
             $groupToBatchTasks = collect($result->fetchAllRows() ?: [])
                 ->groupBy('api_batch_task_group')
                 ->sortKeys()
@@ -306,26 +303,27 @@ class Batch extends Base
                         function () use (
                             $objectMethod,
                             $callData,
-                            $batchId,
+                            $batchGuid,
                             $task
                         ) {
                             return Router::executeCallAsync(
                                 $objectMethod,
                                 $callData,
-                                function (array &$callData) use ($batchId) {
+                                function (array &$callData) use ($batchGuid) {
                                     // fix references in call data using batch cache results
                                     array_walk_recursive(
                                         $callData,
                                         function (&$value, $key, array $presentResults) {
                                             self::fixupReferences($value, $key, $presentResults);
                                         },
-                                        $this->cachedBatchResults[$batchId]
+                                        $this->cachedBatchResults[$batchGuid]
                                     );
                                 },
-                                function (&$payload) use ($batchId, $task) {
+                                function (&$payload) use ($batchGuid, $task) {
                                     // fill batch cache results
-                                    $this->cachedBatchResults[$batchId][$task['api_batch_task_reference_identifier']] =
-                                        $payload;
+                                    $this->cachedBatchResults[$batchGuid][
+                                        $task['api_batch_task_reference_identifier']
+                                    ] = $payload;
                                 }
                             );
                         }
@@ -337,20 +335,20 @@ class Batch extends Base
             }
 
             return chain($chain)
-                ->then(function (array $taskResultsContainer) use ($batchId) {
+                ->then(function (array $taskResultsContainer) use ($batchGuid) {
                     $qb = $this->getAsyncDatabase()->createQueryBuilder();
                     return $this->getAsyncDatabase()->query(
                         $qb
                             ->update('api_batch')
                             ->set('api_batch_state', $qb->createPositionalParameter('Success'))
                             ->set('api_batch_lastupdate', $qb->createPositionalParameter(microtime(true)))
-                            ->where($qb->expr()->eq('api_batch_id', $batchId))
+                            ->where($qb->expr()->eq('api_batch_guid', $qb->createPositionalParameter($batchGuid)))
                     )
-                    ->then(function (/* Result $result */) use ($taskResultsContainer, $batchId) {
+                    ->then(function (/* Result $result */) use ($taskResultsContainer, $batchGuid) {
                         $batchResult = [];
                         foreach ($taskResultsContainer as $groupId => $taskResults) {
                             foreach ($taskResults as $taskId => $taskResult) {
-                                $batchResult[$batchId]['results'][] = [
+                                $batchResult[$batchGuid]['results'][] = [
                                     'call_id' => $taskId,
                                     'payload' => json_encode($taskResult) ?: null
                                 ];
@@ -359,7 +357,7 @@ class Batch extends Base
                         return $batchResult;
                     });
                 })
-                ->otherwise(function ($reason) use ($batchId) {
+                ->otherwise(function ($reason) use ($batchGuid) {
                     // run async query to set batches to failed, no need to wait for the result.
                     $qb = $this->getAsyncDatabase()->createQueryBuilder();
                     $this->getAsyncDatabase()->query(
@@ -367,14 +365,14 @@ class Batch extends Base
                             ->update('api_batch')
                             ->set('api_batch_state', $qb->createPositionalParameter('Failed'))
                             ->set('api_batch_lastupdate', $qb->createPositionalParameter(microtime(true)))
-                            ->where($qb->expr()->eq('api_batch_id', $batchId))
+                            ->where($qb->expr()->eq('api_batch_guid', $qb->createPositionalParameter($batchGuid)))
                     );
                     // Propagate by returning rejection
                     return reject($reason);
                 })
-                ->always(function () use ($batchId) {
+                ->always(function () use ($batchGuid) {
                     // clean up batch cache results
-                    unset($this->cachedBatchResults[$batchId]);
+                    unset($this->cachedBatchResults[$batchGuid]);
                 });
         });
     }

--- a/api_test/test.batch.php
+++ b/api_test/test.batch.php
@@ -1,221 +1,225 @@
 <?php
 
+// needs rewriting
+
 // phpcs:ignore PSR1.Classes.ClassDeclaration.MissingNamespace
-class TestBatch extends TestBase
-{
-    public function __construct(string $token)
-    {
-        parent::__construct($token);
-    }
-
-    /**
-     * @TestMethod
-     */
-    public function StartBatch() // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    {
-        $response = $this->DoApiRequest("/api/batch/StartBatch", array());
-        Assert::ExpectIntValue($response);
-    }
-
-    /**
-     * @TestMethod
-     */
-    public function AddToBatch() // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    {
-        $batchId = $this->DoApiRequest("/api/batch/StartBatch", array());
-        $response = $this->DoApiRequest("/api/batch/AddToBatch", array(
-            "batch_id" => $batchId, "batch_group" => 0, "call_id"=> null, "endpoint"=>"api/geometry/post",
-            "endpoint_data"=>json_encode(array())));
-        Assert::ExpectStringValue($response);
-    }
-
-    /**
-     * @TestMethod
-     */
-    public function ExecuteBatch() // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    {
-        $batchId = $this->DoApiRequest("/api/batch/StartBatch", array());
-        $executeId = $this->DoApiRequest("/api/batch/AddToBatch", array("batch_id" => $batchId,
-            "batch_group" => 0,
-            "call_id"=> "CurrentMonth",
-            "endpoint"=>"api/game/GetCurrentMonth",
-            "endpoint_data"=>json_encode(array())
-        ));
-
-        $executeId = $this->DoApiRequest("/api/batch/AddToBatch", array("batch_id" => $batchId,
-            "batch_group" => 0,
-            "call_id"=> "ActualDate",
-            "endpoint"=>"api/game/GetActualDateForSimulatedMonth",
-            "endpoint_data"=>json_encode(array("simulated_month" => 10))
-        ));
-
-        $executeId = $this->DoApiRequest("/api/batch/AddToBatch", array("batch_id" => $batchId,
-            "batch_group" => 0,
-            "call_id"=> "ActualDate",
-            "endpoint"=>"api/energy/AddGrid",
-            "endpoint_data"=>'{
-				"name": "Green 5",
-				"plan": 5,
-				"distribution_only": "false",
-				"persistent": 21
-			  }'
-        ));
-
-        $result = $this->DoApiRequest("/api/batch/ExecuteBatch", array("batch_id" => $batchId));
-        Assert::ExpectArrayValues($result, Assert::CONSTRAINT_ARRAY, ["results"]);
-        Assert::ExpectStringValue($result["results"][0]["call_id"], "CurrentMonth");
-        Assert::ExpectArrayValues($result["results"][0]["payload"], Assert::CONSTRAINT_INT, ["game_currentmonth"]);
-        Assert::ExpectStringValue($result["results"][1]["call_id"], "ActualDate");
-        Assert::ExpectArrayValues($result["results"][1]["payload"], Assert::CONSTRAINT_INT, ["year", "month_of_year"]);
-    }
-
-    /**
-     * @TestMethod
-     */
-    public function ExecuteBatchReferenced() // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    {
-        $batchId = $this->DoApiRequest("/api/batch/StartBatch", array());
-        $this->DoApiRequest("/api/batch/AddToBatch", array(
-            "batch_id" => $batchId,
-            "batch_group" => 0,
-            "call_id"=> "PlanCreate",
-            "endpoint"=>"api/plan/post",
-            "endpoint_data"=>json_encode(array(
-                "country" => 3,
-                "name" => "Batch Test Plan #1",
-                "time" => 120,
-                "layers" => [],
-                "type" => "0,0,0",
-                "alters_energy_distribution" => false))
-        ));
-        $this->DoApiRequest("/api/batch/AddToBatch", array(
-            "batch_id" => $batchId,
-            "batch_group" => 1,
-            "call_id"=> "PlanLayer",
-            "endpoint"=>"api/plan/layer",
-            "endpoint_data"=>json_encode(array(
-                "id" => "!Ref:PlanCreate",
-                "layerid" => 2))
-        ));
-        $this->DoApiRequest("/api/batch/AddToBatch", array(
-            "batch_id" => $batchId,
-            "batch_group" => 2,
-            "call_id"=> "GeometryCreate0",
-            "endpoint"=>"api/geometry/post",
-            "endpoint_data"=>json_encode(array(
-                "country" => 3,
-                "plan" => "!Ref:PlanCreate",
-                "layer" => "!Ref:PlanLayer",
-                "geometry" => "[[3488833.0042704,3924473.5412358]]"))
-        ));
-        $this->DoApiRequest("/api/batch/AddToBatch", array(
-            "batch_id" => $batchId,
-            "batch_group" => 3,
-            "call_id"=> "GeometryCreate1",
-            "endpoint"=>"api/geometry/post",
-            "endpoint_data"=>json_encode(array(
-                "country" => 3,
-                "plan" => "!Ref:PlanCreate",
-                "layer" => "!Ref:PlanLayer",
-                "geometry" => "[[3488833.0042704,3924473.5412358]]"))
-        ));
-        $result = $this->DoApiRequest("/api/batch/ExecuteBatch", array("batch_id" => $batchId));
-
-        Assert::ExpectArrayValues($result, Assert::CONSTRAINT_ARRAY, ["results"]);
-        Assert::ExpectStringValue($result["results"][0]["call_id"], "PlanCreate");
-        Assert::ExpectStringValue($result["results"][1]["call_id"], "PlanLayer");
-        Assert::ExpectStringValue($result["results"][2]["call_id"], "GeometryCreate0");
-        Assert::ExpectStringValue($result["results"][3]["call_id"], "GeometryCreate1");
-
-        Assert::ExpectIntValue($result["results"][0]["payload"]);
-        Assert::ExpectIntValue($result["results"][1]["payload"]);
-        Assert::ExpectIntValue($result["results"][2]["payload"]);
-        Assert::ExpectIntValue($result["results"][3]["payload"]);
-    }
-
-    /**
-     * @TestMethod
-     */
-    public function ExecuteBatchMultiReferenced() // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    {
-        $batchId = $this->DoApiRequest("/api/batch/StartBatch", array());
-        $this->DoApiRequest("/api/batch/AddToBatch", array(
-            "batch_id" => $batchId,
-            "batch_group" => 0,
-            "call_id"=> "PlanCreate",
-            "endpoint"=>"api/plan/post",
-            "endpoint_data"=>json_encode(array(
-                "country" => 3,
-                "name" => "Batch Test Plan #2",
-                "time" => 120,
-                "layers" => [],
-                "type" => "0,0,0",
-                "alters_energy_distribution" => false))
-        ));
-        $this->DoApiRequest("/api/batch/AddToBatch", array(
-            "batch_id" => $batchId,
-            "batch_group" => 1,
-            "call_id"=> "PlanLayer",
-            "endpoint"=>"api/plan/layer",
-            "endpoint_data"=>json_encode(array(
-                "id" => "!Ref:PlanCreate",
-                "layerid" => 2))
-        ));
-        $this->DoApiRequest("/api/batch/AddToBatch", array(
-            "batch_id" => $batchId,
-            "batch_group" => 4,
-            "call_id"=> "AddGrid1",
-            "endpoint"=>"api/energy/AddGrid",
-            "endpoint_data"=>json_encode(array(
-                "name" => "TestGrid",
-                "plan" => "!Ref:PlanCreate",
-                "distribution_only" => "false"))
-        ));
-        $this->DoApiRequest("/api/batch/AddToBatch", array(
-            "batch_id" => $batchId,
-            "batch_group" => 5,
-            "call_id"=> "UpdateGridSources1",
-            "endpoint"=>"api/energy/UpdateGridSources",
-            "endpoint_data"=>json_encode(array(
-                "id" => "!Ref:AddGrid1",
-                "sources" => ["!Ref:GeometryCreate0", "!Ref:GeometryCreate1"]))
-        ));
-        $this->DoApiRequest("/api/batch/AddToBatch", array(
-            "batch_id" => $batchId,
-            "batch_group" => 2,
-            "call_id"=> "GeometryCreate0",
-            "endpoint"=>"api/geometry/post",
-            "endpoint_data"=>json_encode(array(
-                "country" => 3,
-                "plan" => "!Ref:PlanCreate",
-                "layer" => "!Ref:PlanLayer",
-                "geometry" => "[[3488833.0042704,3924473.5412358]]"))
-        ));
-        $this->DoApiRequest("/api/batch/AddToBatch", array(
-            "batch_id" => $batchId,
-            "batch_group" => 3,
-            "call_id"=> "GeometryCreate1",
-            "endpoint"=>"api/geometry/post",
-            "endpoint_data"=>json_encode(array(
-                "country" => 3,
-                "plan" => "!Ref:PlanCreate",
-                "layer" => "!Ref:PlanLayer",
-                "geometry" => "[[3488833.0042704,3924473.5412358]]"))
-        ));
-        $result = $this->DoApiRequest("/api/batch/ExecuteBatch", array("batch_id" => $batchId));
-        
-        Assert::ExpectArrayValues($result, Assert::CONSTRAINT_ARRAY, ["results"]);
-        Assert::ExpectStringValue($result["results"][0]["call_id"], "PlanCreate");
-        Assert::ExpectStringValue($result["results"][1]["call_id"], "PlanLayer");
-        Assert::ExpectStringValue($result["results"][2]["call_id"], "GeometryCreate0");
-        Assert::ExpectStringValue($result["results"][3]["call_id"], "GeometryCreate1");
-        Assert::ExpectStringValue($result["results"][4]["call_id"], "AddGrid1");
-        Assert::ExpectStringValue($result["results"][5]["call_id"], "UpdateGridSources1");
-
-        Assert::ExpectIntValue($result["results"][0]["payload"]);
-        Assert::ExpectIntValue($result["results"][1]["payload"]);
-        Assert::ExpectIntValue($result["results"][2]["payload"]);
-        Assert::ExpectIntValue($result["results"][3]["payload"]);
-        Assert::ExpectIntValue($result["results"][4]["payload"]);
-    }
-}
+//class TestBatch extends TestBase
+//{
+//    public function __construct(string $token)
+//    {
+//        parent::__construct($token);
+//    }
+//
+//    /**
+//     * @TestMethod
+//     */
+//    public function StartBatch() // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+//    {
+//        $response = $this->DoApiRequest("/api/batch/StartBatch", array());
+//        Assert::ExpectIntValue($response);
+//    }
+//
+//    /**
+//     * @TestMethod
+//     */
+//    public function AddToBatch() // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+//    {
+//        $batchId = $this->DoApiRequest("/api/batch/StartBatch", array());
+//        $response = $this->DoApiRequest("/api/batch/AddToBatch", array(
+//            "batch_id" => $batchId, "batch_group" => 0, "call_id"=> null, "endpoint"=>"api/geometry/post",
+//            "endpoint_data"=>json_encode(array())));
+//        Assert::ExpectStringValue($response);
+//    }
+//
+//    /**
+//     * @TestMethod
+//     */
+//    public function ExecuteBatch() // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+//    {
+//        $batchId = $this->DoApiRequest("/api/batch/StartBatch", array());
+//        $executeId = $this->DoApiRequest("/api/batch/AddToBatch", array("batch_id" => $batchId,
+//            "batch_group" => 0,
+//            "call_id"=> "CurrentMonth",
+//            "endpoint"=>"api/game/GetCurrentMonth",
+//            "endpoint_data"=>json_encode(array())
+//        ));
+//
+//        $executeId = $this->DoApiRequest("/api/batch/AddToBatch", array("batch_id" => $batchId,
+//            "batch_group" => 0,
+//            "call_id"=> "ActualDate",
+//            "endpoint"=>"api/game/GetActualDateForSimulatedMonth",
+//            "endpoint_data"=>json_encode(array("simulated_month" => 10))
+//        ));
+//
+//        $executeId = $this->DoApiRequest("/api/batch/AddToBatch", array("batch_id" => $batchId,
+//            "batch_group" => 0,
+//            "call_id"=> "ActualDate",
+//            "endpoint"=>"api/energy/AddGrid",
+//            "endpoint_data"=>'{
+//              "name": "Green 5",
+//              "plan": 5,
+//              "distribution_only": "false",
+//              "persistent": 21
+//            }'
+//        ));
+//
+//        $result = $this->DoApiRequest("/api/batch/ExecuteBatch", array("batch_id" => $batchId));
+//        Assert::ExpectArrayValues($result, Assert::CONSTRAINT_ARRAY, ["results"]);
+//        Assert::ExpectStringValue($result["results"][0]["call_id"], "CurrentMonth");
+//        Assert::ExpectArrayValues($result["results"][0]["payload"], Assert::CONSTRAINT_INT, ["game_currentmonth"]);
+//        Assert::ExpectStringValue($result["results"][1]["call_id"], "ActualDate");
+//        Assert::ExpectArrayValues(
+//            $result["results"][1]["payload"], Assert::CONSTRAINT_INT, ["year", "month_of_year"]
+//        );
+//    }
+//
+//    /**
+//     * @TestMethod
+//     */
+//    public function ExecuteBatchReferenced() // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+//    {
+//        $batchId = $this->DoApiRequest("/api/batch/StartBatch", array());
+//        $this->DoApiRequest("/api/batch/AddToBatch", array(
+//            "batch_id" => $batchId,
+//            "batch_group" => 0,
+//            "call_id"=> "PlanCreate",
+//            "endpoint"=>"api/plan/post",
+//            "endpoint_data"=>json_encode(array(
+//                "country" => 3,
+//                "name" => "Batch Test Plan #1",
+//                "time" => 120,
+//                "layers" => [],
+//                "type" => "0,0,0",
+//                "alters_energy_distribution" => false))
+//        ));
+//        $this->DoApiRequest("/api/batch/AddToBatch", array(
+//            "batch_id" => $batchId,
+//            "batch_group" => 1,
+//            "call_id"=> "PlanLayer",
+//            "endpoint"=>"api/plan/layer",
+//            "endpoint_data"=>json_encode(array(
+//                "id" => "!Ref:PlanCreate",
+//                "layerid" => 2))
+//        ));
+//        $this->DoApiRequest("/api/batch/AddToBatch", array(
+//            "batch_id" => $batchId,
+//            "batch_group" => 2,
+//            "call_id"=> "GeometryCreate0",
+//            "endpoint"=>"api/geometry/post",
+//            "endpoint_data"=>json_encode(array(
+//                "country" => 3,
+//                "plan" => "!Ref:PlanCreate",
+//                "layer" => "!Ref:PlanLayer",
+//                "geometry" => "[[3488833.0042704,3924473.5412358]]"))
+//        ));
+//        $this->DoApiRequest("/api/batch/AddToBatch", array(
+//            "batch_id" => $batchId,
+//            "batch_group" => 3,
+//            "call_id"=> "GeometryCreate1",
+//            "endpoint"=>"api/geometry/post",
+//            "endpoint_data"=>json_encode(array(
+//                "country" => 3,
+//                "plan" => "!Ref:PlanCreate",
+//                "layer" => "!Ref:PlanLayer",
+//                "geometry" => "[[3488833.0042704,3924473.5412358]]"))
+//        ));
+//        $result = $this->DoApiRequest("/api/batch/ExecuteBatch", array("batch_id" => $batchId));
+//
+//        Assert::ExpectArrayValues($result, Assert::CONSTRAINT_ARRAY, ["results"]);
+//        Assert::ExpectStringValue($result["results"][0]["call_id"], "PlanCreate");
+//        Assert::ExpectStringValue($result["results"][1]["call_id"], "PlanLayer");
+//        Assert::ExpectStringValue($result["results"][2]["call_id"], "GeometryCreate0");
+//        Assert::ExpectStringValue($result["results"][3]["call_id"], "GeometryCreate1");
+//
+//        Assert::ExpectIntValue($result["results"][0]["payload"]);
+//        Assert::ExpectIntValue($result["results"][1]["payload"]);
+//        Assert::ExpectIntValue($result["results"][2]["payload"]);
+//        Assert::ExpectIntValue($result["results"][3]["payload"]);
+//    }
+//
+//    /**
+//     * @TestMethod
+//     */
+//    public function ExecuteBatchMultiReferenced() // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+//    {
+//        $batchId = $this->DoApiRequest("/api/batch/StartBatch", array());
+//        $this->DoApiRequest("/api/batch/AddToBatch", array(
+//            "batch_id" => $batchId,
+//            "batch_group" => 0,
+//            "call_id"=> "PlanCreate",
+//            "endpoint"=>"api/plan/post",
+//            "endpoint_data"=>json_encode(array(
+//                "country" => 3,
+//                "name" => "Batch Test Plan #2",
+//                "time" => 120,
+//                "layers" => [],
+//                "type" => "0,0,0",
+//                "alters_energy_distribution" => false))
+//        ));
+//        $this->DoApiRequest("/api/batch/AddToBatch", array(
+//            "batch_id" => $batchId,
+//            "batch_group" => 1,
+//            "call_id"=> "PlanLayer",
+//            "endpoint"=>"api/plan/layer",
+//            "endpoint_data"=>json_encode(array(
+//                "id" => "!Ref:PlanCreate",
+//                "layerid" => 2))
+//        ));
+//        $this->DoApiRequest("/api/batch/AddToBatch", array(
+//            "batch_id" => $batchId,
+//            "batch_group" => 4,
+//            "call_id"=> "AddGrid1",
+//            "endpoint"=>"api/energy/AddGrid",
+//            "endpoint_data"=>json_encode(array(
+//                "name" => "TestGrid",
+//                "plan" => "!Ref:PlanCreate",
+//                "distribution_only" => "false"))
+//        ));
+//        $this->DoApiRequest("/api/batch/AddToBatch", array(
+//            "batch_id" => $batchId,
+//            "batch_group" => 5,
+//            "call_id"=> "UpdateGridSources1",
+//            "endpoint"=>"api/energy/UpdateGridSources",
+//            "endpoint_data"=>json_encode(array(
+//                "id" => "!Ref:AddGrid1",
+//                "sources" => ["!Ref:GeometryCreate0", "!Ref:GeometryCreate1"]))
+//        ));
+//        $this->DoApiRequest("/api/batch/AddToBatch", array(
+//            "batch_id" => $batchId,
+//            "batch_group" => 2,
+//            "call_id"=> "GeometryCreate0",
+//            "endpoint"=>"api/geometry/post",
+//            "endpoint_data"=>json_encode(array(
+//                "country" => 3,
+//                "plan" => "!Ref:PlanCreate",
+//                "layer" => "!Ref:PlanLayer",
+//                "geometry" => "[[3488833.0042704,3924473.5412358]]"))
+//        ));
+//        $this->DoApiRequest("/api/batch/AddToBatch", array(
+//            "batch_id" => $batchId,
+//            "batch_group" => 3,
+//            "call_id"=> "GeometryCreate1",
+//            "endpoint"=>"api/geometry/post",
+//            "endpoint_data"=>json_encode(array(
+//                "country" => 3,
+//                "plan" => "!Ref:PlanCreate",
+//                "layer" => "!Ref:PlanLayer",
+//                "geometry" => "[[3488833.0042704,3924473.5412358]]"))
+//        ));
+//        $result = $this->DoApiRequest("/api/batch/ExecuteBatch", array("batch_id" => $batchId));
+//
+//        Assert::ExpectArrayValues($result, Assert::CONSTRAINT_ARRAY, ["results"]);
+//        Assert::ExpectStringValue($result["results"][0]["call_id"], "PlanCreate");
+//        Assert::ExpectStringValue($result["results"][1]["call_id"], "PlanLayer");
+//        Assert::ExpectStringValue($result["results"][2]["call_id"], "GeometryCreate0");
+//        Assert::ExpectStringValue($result["results"][3]["call_id"], "GeometryCreate1");
+//        Assert::ExpectStringValue($result["results"][4]["call_id"], "AddGrid1");
+//        Assert::ExpectStringValue($result["results"][5]["call_id"], "UpdateGridSources1");
+//
+//        Assert::ExpectIntValue($result["results"][0]["payload"]);
+//        Assert::ExpectIntValue($result["results"][1]["payload"]);
+//        Assert::ExpectIntValue($result["results"][2]["payload"]);
+//        Assert::ExpectIntValue($result["results"][3]["payload"]);
+//        Assert::ExpectIntValue($result["results"][4]["payload"]);
+//    }
+//}

--- a/composer-symfony5.4.lock
+++ b/composer-symfony5.4.lock
@@ -562,16 +562,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "3.5.3",
+            "version": "3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "88fa7e5189fd5ec6682477044264dc0ed4e3aa1e"
+                "reference": "57815c7bbcda3cd18871d253c1dd8cbe56f8526e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/88fa7e5189fd5ec6682477044264dc0ed4e3aa1e",
-                "reference": "88fa7e5189fd5ec6682477044264dc0ed4e3aa1e",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/57815c7bbcda3cd18871d253c1dd8cbe56f8526e",
+                "reference": "57815c7bbcda3cd18871d253c1dd8cbe56f8526e",
                 "shasum": ""
             },
             "require": {
@@ -584,13 +584,14 @@
                 "psr/log": "^1|^2|^3"
             },
             "require-dev": {
-                "doctrine/coding-standard": "11.0.0",
+                "doctrine/coding-standard": "11.1.0",
+                "fig/log-test": "^1",
                 "jetbrains/phpstorm-stubs": "2022.3",
-                "phpstan/phpstan": "1.9.4",
-                "phpstan/phpstan-strict-rules": "^1.4",
-                "phpunit/phpunit": "9.5.27",
+                "phpstan/phpstan": "1.10.3",
+                "phpstan/phpstan-strict-rules": "^1.5",
+                "phpunit/phpunit": "9.6.4",
                 "psalm/plugin-phpunit": "0.18.4",
-                "squizlabs/php_codesniffer": "3.7.1",
+                "squizlabs/php_codesniffer": "3.7.2",
                 "symfony/cache": "^5.4|^6.0",
                 "symfony/console": "^4.4|^5.4|^6.0",
                 "vimeo/psalm": "4.30.0"
@@ -653,7 +654,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.5.3"
+                "source": "https://github.com/doctrine/dbal/tree/3.6.1"
             },
             "funding": [
                 {
@@ -669,7 +670,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-12T10:21:44+00:00"
+            "time": "2023-03-02T19:26:24+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -716,16 +717,16 @@
         },
         {
             "name": "doctrine/doctrine-bundle",
-            "version": "2.8.2",
+            "version": "2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineBundle.git",
-                "reference": "251cd5aaea32bb92cdad4204840786b317dcdd4c"
+                "reference": "fd67ba64db3c806f626a33dcab15a4db0c77652e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/251cd5aaea32bb92cdad4204840786b317dcdd4c",
-                "reference": "251cd5aaea32bb92cdad4204840786b317dcdd4c",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/fd67ba64db3c806f626a33dcab15a4db0c77652e",
+                "reference": "fd67ba64db3c806f626a33dcab15a4db0c77652e",
                 "shasum": ""
             },
             "require": {
@@ -739,7 +740,7 @@
                 "symfony/console": "^5.4 || ^6.0",
                 "symfony/dependency-injection": "^5.4 || ^6.0",
                 "symfony/deprecation-contracts": "^2.1 || ^3",
-                "symfony/doctrine-bridge": "^5.4.7 || ^6.0.7",
+                "symfony/doctrine-bridge": "^5.4.19 || ^6.0.7",
                 "symfony/framework-bundle": "^5.4 || ^6.0",
                 "symfony/service-contracts": "^1.1.1 || ^2.0 || ^3"
             },
@@ -811,7 +812,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/DoctrineBundle/issues",
-                "source": "https://github.com/doctrine/DoctrineBundle/tree/2.8.2"
+                "source": "https://github.com/doctrine/DoctrineBundle/tree/2.8.3"
             },
             "funding": [
                 {
@@ -827,7 +828,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-06T11:42:10+00:00"
+            "time": "2023-02-03T09:32:42+00:00"
         },
         {
             "name": "doctrine/doctrine-migrations-bundle",
@@ -1247,16 +1248,16 @@
         },
         {
             "name": "doctrine/migrations",
-            "version": "3.5.5",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "4b1e2b6ba71d21d0c5be22ed03b6fc954d20b204"
+                "reference": "e542ad8bcd606d7a18d0875babb8a6d963c9c059"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/4b1e2b6ba71d21d0c5be22ed03b6fc954d20b204",
-                "reference": "4b1e2b6ba71d21d0c5be22ed03b6fc954d20b204",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/e542ad8bcd606d7a18d0875babb8a6d963c9c059",
+                "reference": "e542ad8bcd606d7a18d0875babb8a6d963c9c059",
                 "shasum": ""
             },
             "require": {
@@ -1264,11 +1265,11 @@
                 "doctrine/dbal": "^3.5.1",
                 "doctrine/deprecations": "^0.5.3 || ^1",
                 "doctrine/event-manager": "^1.2 || ^2.0",
-                "friendsofphp/proxy-manager-lts": "^1.0",
-                "php": "^7.4 || ^8.0",
+                "php": "^8.1",
                 "psr/log": "^1.1.3 || ^2 || ^3",
                 "symfony/console": "^4.4.16 || ^5.4 || ^6.0",
-                "symfony/stopwatch": "^4.4 || ^5.4 || ^6.0"
+                "symfony/stopwatch": "^4.4 || ^5.4 || ^6.0",
+                "symfony/var-exporter": "^6.2"
             },
             "conflict": {
                 "doctrine/orm": "<2.12"
@@ -1284,7 +1285,7 @@
                 "phpstan/phpstan-phpunit": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.1",
                 "phpstan/phpstan-symfony": "^1.1",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^9.5.24",
                 "symfony/cache": "^4.4 || ^5.4 || ^6.0",
                 "symfony/process": "^4.4 || ^5.4 || ^6.0",
                 "symfony/yaml": "^4.4 || ^5.4 || ^6.0"
@@ -1329,7 +1330,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/migrations/issues",
-                "source": "https://github.com/doctrine/migrations/tree/3.5.5"
+                "source": "https://github.com/doctrine/migrations/tree/3.6.0"
             },
             "funding": [
                 {
@@ -1345,7 +1346,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-18T12:44:30+00:00"
+            "time": "2023-02-15T18:49:46+00:00"
         },
         {
             "name": "doctrine/orm",
@@ -1450,16 +1451,16 @@
         },
         {
             "name": "doctrine/persistence",
-            "version": "3.1.3",
+            "version": "3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "920da294b4bb0bb527f2a91ed60c18213435880f"
+                "reference": "8bf8ab15960787f1a49d405f6eb8c787b4841119"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/920da294b4bb0bb527f2a91ed60c18213435880f",
-                "reference": "920da294b4bb0bb527f2a91ed60c18213435880f",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/8bf8ab15960787f1a49d405f6eb8c787b4841119",
+                "reference": "8bf8ab15960787f1a49d405f6eb8c787b4841119",
                 "shasum": ""
             },
             "require": {
@@ -1528,7 +1529,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/persistence/issues",
-                "source": "https://github.com/doctrine/persistence/tree/3.1.3"
+                "source": "https://github.com/doctrine/persistence/tree/3.1.4"
             },
             "funding": [
                 {
@@ -1544,7 +1545,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-19T13:39:42+00:00"
+            "time": "2023-02-03T11:13:07+00:00"
         },
         {
             "name": "doctrine/sql-formatter",
@@ -1604,12 +1605,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/driftphp/reactphp-dbal.git",
-                "reference": "649a0ba9dcdef54afa167784ee9f68bde01d5037"
+                "reference": "ea83ca51295cc66a240f041285e588d4f12abf95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/driftphp/reactphp-dbal/zipball/649a0ba9dcdef54afa167784ee9f68bde01d5037",
-                "reference": "649a0ba9dcdef54afa167784ee9f68bde01d5037",
+                "url": "https://api.github.com/repos/driftphp/reactphp-dbal/zipball/ea83ca51295cc66a240f041285e588d4f12abf95",
+                "reference": "ea83ca51295cc66a240f041285e588d4f12abf95",
                 "shasum": ""
             },
             "require": {
@@ -1651,7 +1652,7 @@
                 "issues": "https://github.com/driftphp/reactphp-dbal/issues",
                 "source": "https://github.com/driftphp/reactphp-dbal/tree/master"
             },
-            "time": "2022-05-26T09:56:02+00:00"
+            "time": "2023-03-09T21:48:43+00:00"
         },
         {
             "name": "evenement/evenement",
@@ -1892,16 +1893,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.4.3",
+            "version": "2.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "67c26b443f348a51926030c83481b85718457d3d"
+                "reference": "3cf1b6d4f0c820a2cf8bcaec39fc698f3443b5cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/67c26b443f348a51926030c83481b85718457d3d",
-                "reference": "67c26b443f348a51926030c83481b85718457d3d",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/3cf1b6d4f0c820a2cf8bcaec39fc698f3443b5cf",
+                "reference": "3cf1b6d4f0c820a2cf8bcaec39fc698f3443b5cf",
                 "shasum": ""
             },
             "require": {
@@ -1991,7 +1992,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.4.3"
+                "source": "https://github.com/guzzle/psr7/tree/2.4.4"
             },
             "funding": [
                 {
@@ -2007,7 +2008,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-26T14:07:24+00:00"
+            "time": "2023-03-09T13:19:02+00:00"
         },
         {
             "name": "illuminate/collections",
@@ -2159,29 +2160,29 @@
         },
         {
             "name": "laminas/laminas-code",
-            "version": "4.8.0",
+            "version": "4.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-code.git",
-                "reference": "dd19fe8e07cc3f374308565667eecd4958c22106"
+                "reference": "ad8b36073f9ac792716478befadca0798cc15635"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/dd19fe8e07cc3f374308565667eecd4958c22106",
-                "reference": "dd19fe8e07cc3f374308565667eecd4958c22106",
+                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/ad8b36073f9ac792716478befadca0798cc15635",
+                "reference": "ad8b36073f9ac792716478befadca0798cc15635",
                 "shasum": ""
             },
             "require": {
                 "php": "~8.1.0 || ~8.2.0"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.13.3",
+                "doctrine/annotations": "^2.0.0",
                 "ext-phar": "*",
                 "laminas/laminas-coding-standard": "^2.3.0",
                 "laminas/laminas-stdlib": "^3.6.1",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.1.0"
+                "phpunit/phpunit": "^10.0.9",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.7.1"
             },
             "suggest": {
                 "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
@@ -2218,7 +2219,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-08T02:08:23+00:00"
+            "time": "2023-03-08T11:55:01+00:00"
         },
         {
             "name": "lcobucci/clock",
@@ -3710,16 +3711,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "e9147c89fdfdc5d5ef798bb7193f23726ad609f5"
+                "reference": "32cab695bf99c63aff7d27ac67919944c00530ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/e9147c89fdfdc5d5ef798bb7193f23726ad609f5",
-                "reference": "e9147c89fdfdc5d5ef798bb7193f23726ad609f5",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/32cab695bf99c63aff7d27ac67919944c00530ed",
+                "reference": "32cab695bf99c63aff7d27ac67919944c00530ed",
                 "shasum": ""
             },
             "require": {
@@ -3787,7 +3788,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v5.4.19"
+                "source": "https://github.com/symfony/cache/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -3803,7 +3804,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-19T09:49:58+00:00"
+            "time": "2023-02-21T12:11:13+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -3886,16 +3887,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "9bd60843443cda9638efdca7c41eb82ed0026179"
+                "reference": "2a6b1111d038adfa15d52c0871e540f3b352d1e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/9bd60843443cda9638efdca7c41eb82ed0026179",
-                "reference": "9bd60843443cda9638efdca7c41eb82ed0026179",
+                "url": "https://api.github.com/repos/symfony/config/zipball/2a6b1111d038adfa15d52c0871e540f3b352d1e4",
+                "reference": "2a6b1111d038adfa15d52c0871e540f3b352d1e4",
                 "shasum": ""
             },
             "require": {
@@ -3945,7 +3946,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.4.19"
+                "source": "https://github.com/symfony/config/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -3961,20 +3962,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-08T13:23:55+00:00"
+            "time": "2023-02-14T08:03:56+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "dccb8d251a9017d5994c988b034d3e18aaabf740"
+                "reference": "c77433ddc6cdc689caf48065d9ea22ca0853fbd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/dccb8d251a9017d5994c988b034d3e18aaabf740",
-                "reference": "dccb8d251a9017d5994c988b034d3e18aaabf740",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c77433ddc6cdc689caf48065d9ea22ca0853fbd9",
+                "reference": "c77433ddc6cdc689caf48065d9ea22ca0853fbd9",
                 "shasum": ""
             },
             "require": {
@@ -4044,7 +4045,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.19"
+                "source": "https://github.com/symfony/console/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -4060,20 +4061,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-25T16:59:41+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "99dae35f2b7d1bd9b800fcda4173215fc9f79ba3"
+                "reference": "5bc403d96622cf0091abd92c939eadecd4d07f94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/99dae35f2b7d1bd9b800fcda4173215fc9f79ba3",
-                "reference": "99dae35f2b7d1bd9b800fcda4173215fc9f79ba3",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/5bc403d96622cf0091abd92c939eadecd4d07f94",
+                "reference": "5bc403d96622cf0091abd92c939eadecd4d07f94",
                 "shasum": ""
             },
             "require": {
@@ -4133,7 +4134,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.19"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -4149,20 +4150,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-23T15:37:22+00:00"
+            "time": "2023-02-16T09:33:00+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "1ee04c65529dea5d8744774d474e7cbd2f1206d3"
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/1ee04c65529dea5d8744774d474e7cbd2f1206d3",
-                "reference": "1ee04c65529dea5d8744774d474e7cbd2f1206d3",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
                 "shasum": ""
             },
             "require": {
@@ -4200,7 +4201,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.1"
             },
             "funding": [
                 {
@@ -4216,20 +4217,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-25T10:21:52+00:00"
+            "time": "2023-03-01T10:25:55+00:00"
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "359ba96a1e494f1fc08b36d51a74d2fe01d68e68"
+                "reference": "d0ec59b38d87bcaa4dab5717be98433fa3db58dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/359ba96a1e494f1fc08b36d51a74d2fe01d68e68",
-                "reference": "359ba96a1e494f1fc08b36d51a74d2fe01d68e68",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/d0ec59b38d87bcaa4dab5717be98433fa3db58dc",
+                "reference": "d0ec59b38d87bcaa4dab5717be98433fa3db58dc",
                 "shasum": ""
             },
             "require": {
@@ -4249,7 +4250,7 @@
                 "phpunit/phpunit": "<5.4.3",
                 "symfony/cache": "<5.4",
                 "symfony/dependency-injection": "<4.4",
-                "symfony/form": "<5.1",
+                "symfony/form": "<5.4.21|>=6,<6.2.7",
                 "symfony/http-kernel": "<5",
                 "symfony/messenger": "<4.4",
                 "symfony/property-info": "<5",
@@ -4270,7 +4271,7 @@
                 "symfony/dependency-injection": "^4.4|^5.0|^6.0",
                 "symfony/doctrine-messenger": "^5.1|^6.0",
                 "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/form": "^5.4.9|^6.0.9",
+                "symfony/form": "^5.4.21|^6.2.7",
                 "symfony/http-kernel": "^5.0|^6.0",
                 "symfony/messenger": "^4.4|^5.0|^6.0",
                 "symfony/property-access": "^4.4|^5.0|^6.0",
@@ -4317,7 +4318,7 @@
             "description": "Provides integration for Doctrine with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/doctrine-bridge/tree/v5.4.19"
+                "source": "https://github.com/symfony/doctrine-bridge/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -4333,20 +4334,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-06T12:33:31+00:00"
+            "time": "2023-02-14T08:03:56+00:00"
         },
         {
             "name": "symfony/dotenv",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
-                "reference": "38190ba62566afa26ca723a795d0a004e061bd2a"
+                "reference": "c45210b1c43d2d24e263eefe72e8162754dd4c9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/38190ba62566afa26ca723a795d0a004e061bd2a",
-                "reference": "38190ba62566afa26ca723a795d0a004e061bd2a",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/c45210b1c43d2d24e263eefe72e8162754dd4c9f",
+                "reference": "c45210b1c43d2d24e263eefe72e8162754dd4c9f",
                 "shasum": ""
             },
             "require": {
@@ -4388,7 +4389,7 @@
                 "environment"
             ],
             "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v5.4.19"
+                "source": "https://github.com/symfony/dotenv/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -4404,20 +4405,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-14T08:03:56+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "438ef3e5e6481244785da3ce8cf8f4e74e7f2822"
+                "reference": "56a94aa8cb5a5fbc411551d8d014a296b5456549"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/438ef3e5e6481244785da3ce8cf8f4e74e7f2822",
-                "reference": "438ef3e5e6481244785da3ce8cf8f4e74e7f2822",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/56a94aa8cb5a5fbc411551d8d014a296b5456549",
+                "reference": "56a94aa8cb5a5fbc411551d8d014a296b5456549",
                 "shasum": ""
             },
             "require": {
@@ -4459,7 +4460,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v5.4.19"
+                "source": "https://github.com/symfony/error-handler/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -4475,20 +4476,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-14T08:03:56+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "abf49cc084c087d94b4cb939c3f3672971784e0c"
+                "reference": "f0ae1383a8285dfc6752b8d8602790953118ff5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/abf49cc084c087d94b4cb939c3f3672971784e0c",
-                "reference": "abf49cc084c087d94b4cb939c3f3672971784e0c",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f0ae1383a8285dfc6752b8d8602790953118ff5a",
+                "reference": "f0ae1383a8285dfc6752b8d8602790953118ff5a",
                 "shasum": ""
             },
             "require": {
@@ -4544,7 +4545,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.19"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -4560,20 +4561,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-14T08:03:56+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "0782b0b52a737a05b4383d0df35a474303cabdae"
+                "reference": "0ad3b6f1e4e2da5690fefe075cd53a238646d8dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/0782b0b52a737a05b4383d0df35a474303cabdae",
-                "reference": "0782b0b52a737a05b4383d0df35a474303cabdae",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/0ad3b6f1e4e2da5690fefe075cd53a238646d8dd",
+                "reference": "0ad3b6f1e4e2da5690fefe075cd53a238646d8dd",
                 "shasum": ""
             },
             "require": {
@@ -4623,7 +4624,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.2.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.2.1"
             },
             "funding": [
                 {
@@ -4639,20 +4640,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-25T10:21:52+00:00"
+            "time": "2023-03-01T10:32:47+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "648bfaca6a494f3e22378123bcee2894045dc9d8"
+                "reference": "e75960b1bbfd2b8c9e483e0d74811d555ca3de9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/648bfaca6a494f3e22378123bcee2894045dc9d8",
-                "reference": "648bfaca6a494f3e22378123bcee2894045dc9d8",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e75960b1bbfd2b8c9e483e0d74811d555ca3de9f",
+                "reference": "e75960b1bbfd2b8c9e483e0d74811d555ca3de9f",
                 "shasum": ""
             },
             "require": {
@@ -4687,7 +4688,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.19"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -4703,20 +4704,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-14T19:14:44+00:00"
+            "time": "2023-02-14T08:03:56+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "6071aebf810ad13fe8200c224f36103abb37cf1f"
+                "reference": "078e9a5e1871fcfe6a5ce421b539344c21afef19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/6071aebf810ad13fe8200c224f36103abb37cf1f",
-                "reference": "6071aebf810ad13fe8200c224f36103abb37cf1f",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/078e9a5e1871fcfe6a5ce421b539344c21afef19",
+                "reference": "078e9a5e1871fcfe6a5ce421b539344c21afef19",
                 "shasum": ""
             },
             "require": {
@@ -4750,7 +4751,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.19"
+                "source": "https://github.com/symfony/finder/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -4766,20 +4767,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-14T19:14:44+00:00"
+            "time": "2023-02-16T09:33:00+00:00"
         },
         {
             "name": "symfony/flex",
-            "version": "v1.19.4",
+            "version": "v1.19.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "c82477240111bfe41a1067c9f0ab91d40bafa5b6"
+                "reference": "51077ed0f6dc2c94cd0b670167eee3747c31b2c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/c82477240111bfe41a1067c9f0ab91d40bafa5b6",
-                "reference": "c82477240111bfe41a1067c9f0ab91d40bafa5b6",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/51077ed0f6dc2c94cd0b670167eee3747c31b2c1",
+                "reference": "51077ed0f6dc2c94cd0b670167eee3747c31b2c1",
                 "shasum": ""
             },
             "require": {
@@ -4815,7 +4816,7 @@
             "description": "Composer plugin for Symfony",
             "support": {
                 "issues": "https://github.com/symfony/flex/issues",
-                "source": "https://github.com/symfony/flex/tree/v1.19.4"
+                "source": "https://github.com/symfony/flex/tree/v1.19.5"
             },
             "funding": [
                 {
@@ -4831,20 +4832,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-20T07:19:24+00:00"
+            "time": "2023-01-30T17:02:31+00:00"
         },
         {
             "name": "symfony/form",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/form.git",
-                "reference": "c29e6cccee469ca93db2dbc02a39c29312c5e362"
+                "reference": "39b8a9e6353f8ad95de993ef769295d412991b36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/form/zipball/c29e6cccee469ca93db2dbc02a39c29312c5e362",
-                "reference": "c29e6cccee469ca93db2dbc02a39c29312c5e362",
+                "url": "https://api.github.com/repos/symfony/form/zipball/39b8a9e6353f8ad95de993ef769295d412991b36",
+                "reference": "39b8a9e6353f8ad95de993ef769295d412991b36",
                 "shasum": ""
             },
             "require": {
@@ -4864,13 +4865,13 @@
                 "phpunit/phpunit": "<5.4.3",
                 "symfony/console": "<4.4",
                 "symfony/dependency-injection": "<4.4",
-                "symfony/doctrine-bridge": "<4.4",
+                "symfony/doctrine-bridge": "<5.4.21|>=6,<6.2.7",
                 "symfony/error-handler": "<4.4.5",
                 "symfony/framework-bundle": "<4.4",
                 "symfony/http-kernel": "<4.4",
                 "symfony/translation": "<4.4",
                 "symfony/translation-contracts": "<1.1.7",
-                "symfony/twig-bridge": "<4.4"
+                "symfony/twig-bridge": "<5.4.21|>=6,<6.2.7"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0|^2.0",
@@ -4918,7 +4919,7 @@
             "description": "Allows to easily create, process and reuse HTML forms",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/form/tree/v5.4.19"
+                "source": "https://github.com/symfony/form/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -4934,20 +4935,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-23T17:08:09+00:00"
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "a208ee578000f9dedcb50a9784ec7ff8706a7bf1"
+                "reference": "87623353dea3044c9d34382ffc4c5729cf676c90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/a208ee578000f9dedcb50a9784ec7ff8706a7bf1",
-                "reference": "a208ee578000f9dedcb50a9784ec7ff8706a7bf1",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/87623353dea3044c9d34382ffc4c5729cf676c90",
+                "reference": "87623353dea3044c9d34382ffc4c5729cf676c90",
                 "shasum": ""
             },
             "require": {
@@ -5069,7 +5070,7 @@
             "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/framework-bundle/tree/v5.4.19"
+                "source": "https://github.com/symfony/framework-bundle/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -5085,20 +5086,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-10T17:40:25+00:00"
+            "time": "2023-02-23T09:17:25+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "70fd0eb8a1570ba119d5e496c8ee79bf9f0b51b0"
+                "reference": "3bb6ee5582366c4176d5ce596b380117c8200bbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/70fd0eb8a1570ba119d5e496c8ee79bf9f0b51b0",
-                "reference": "70fd0eb8a1570ba119d5e496c8ee79bf9f0b51b0",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/3bb6ee5582366c4176d5ce596b380117c8200bbf",
+                "reference": "3bb6ee5582366c4176d5ce596b380117c8200bbf",
                 "shasum": ""
             },
             "require": {
@@ -5145,7 +5146,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v5.4.19"
+                "source": "https://github.com/symfony/http-foundation/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -5161,20 +5162,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-17T21:35:35+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "ee371cd7718c938d1bffdf868b665003aeeae69c"
+                "reference": "09c19fc7e4218fbcf73fe0330eea38d66064b775"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/ee371cd7718c938d1bffdf868b665003aeeae69c",
-                "reference": "ee371cd7718c938d1bffdf868b665003aeeae69c",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/09c19fc7e4218fbcf73fe0330eea38d66064b775",
+                "reference": "09c19fc7e4218fbcf73fe0330eea38d66064b775",
                 "shasum": ""
             },
             "require": {
@@ -5183,7 +5184,7 @@
                 "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/error-handler": "^4.4|^5.0|^6.0",
                 "symfony/event-dispatcher": "^5.0|^6.0",
-                "symfony/http-foundation": "^5.3.7|^6.0",
+                "symfony/http-foundation": "^5.4.21|^6.2.7",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-php73": "^1.9",
                 "symfony/polyfill-php80": "^1.16"
@@ -5257,7 +5258,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.4.19"
+                "source": "https://github.com/symfony/http-kernel/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -5273,20 +5274,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-24T13:37:42+00:00"
+            "time": "2023-02-28T13:19:09+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "b03c99236445492f20c61666e8f7e5d388b078e5"
+                "reference": "4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/b03c99236445492f20c61666e8f7e5d388b078e5",
-                "reference": "b03c99236445492f20c61666e8f7e5d388b078e5",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9",
+                "reference": "4fe5cf6ede71096839f0e4b4444d65dd3a7c1eb9",
                 "shasum": ""
             },
             "require": {
@@ -5326,7 +5327,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v5.4.19"
+                "source": "https://github.com/symfony/options-resolver/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -5342,7 +5343,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-14T08:03:56+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -6004,16 +6005,16 @@
         },
         {
             "name": "symfony/property-access",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "20fcf370aed6b2b4a2d8170fa23d2d07250e94ab"
+                "reference": "bbd4442bfbdf3992550772539ba743d6d834534f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/20fcf370aed6b2b4a2d8170fa23d2d07250e94ab",
-                "reference": "20fcf370aed6b2b4a2d8170fa23d2d07250e94ab",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/bbd4442bfbdf3992550772539ba743d6d834534f",
+                "reference": "bbd4442bfbdf3992550772539ba743d6d834534f",
                 "shasum": ""
             },
             "require": {
@@ -6065,7 +6066,7 @@
                 "reflection"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-access/tree/v5.4.19"
+                "source": "https://github.com/symfony/property-access/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -6081,20 +6082,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-16T09:33:00+00:00"
         },
         {
             "name": "symfony/property-info",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "8ccf54bce2e2edbface1e99cb5a2560a290c9e2d"
+                "reference": "722737086d76b4edabfc2d50a48cebd4b8cd5546"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/8ccf54bce2e2edbface1e99cb5a2560a290c9e2d",
-                "reference": "8ccf54bce2e2edbface1e99cb5a2560a290c9e2d",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/722737086d76b4edabfc2d50a48cebd4b8cd5546",
+                "reference": "722737086d76b4edabfc2d50a48cebd4b8cd5546",
                 "shasum": ""
             },
             "require": {
@@ -6156,7 +6157,7 @@
                 "validator"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-info/tree/v5.4.19"
+                "source": "https://github.com/symfony/property-info/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -6172,20 +6173,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-14T11:26:56+00:00"
+            "time": "2023-02-16T09:33:00+00:00"
         },
         {
             "name": "symfony/proxy-manager-bridge",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/proxy-manager-bridge.git",
-                "reference": "02dea4937f05236483ebc3ff97b91bb414111344"
+                "reference": "a4cf96f3acfa252503a216bea877478f9621c7c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/proxy-manager-bridge/zipball/02dea4937f05236483ebc3ff97b91bb414111344",
-                "reference": "02dea4937f05236483ebc3ff97b91bb414111344",
+                "url": "https://api.github.com/repos/symfony/proxy-manager-bridge/zipball/a4cf96f3acfa252503a216bea877478f9621c7c0",
+                "reference": "a4cf96f3acfa252503a216bea877478f9621c7c0",
                 "shasum": ""
             },
             "require": {
@@ -6223,7 +6224,7 @@
             "description": "Provides integration for ProxyManager with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/proxy-manager-bridge/tree/v5.4.19"
+                "source": "https://github.com/symfony/proxy-manager-bridge/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -6239,20 +6240,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-16T09:33:00+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "df1b28f37c8e78912213c58ef6ab2f2037bbfdc5"
+                "reference": "2ea0f3049076e8ef96eab203a809d6b2332f0361"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/df1b28f37c8e78912213c58ef6ab2f2037bbfdc5",
-                "reference": "df1b28f37c8e78912213c58ef6ab2f2037bbfdc5",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/2ea0f3049076e8ef96eab203a809d6b2332f0361",
+                "reference": "2ea0f3049076e8ef96eab203a809d6b2332f0361",
                 "shasum": ""
             },
             "require": {
@@ -6313,7 +6314,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v5.4.19"
+                "source": "https://github.com/symfony/routing/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -6329,20 +6330,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-16T09:33:00+00:00"
         },
         {
             "name": "symfony/runtime",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/runtime.git",
-                "reference": "a33478ef6d8e6ea642449001949aafd330ca0486"
+                "reference": "da8ebb6c2ca375c19a915527fb1b20332b668151"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/runtime/zipball/a33478ef6d8e6ea642449001949aafd330ca0486",
-                "reference": "a33478ef6d8e6ea642449001949aafd330ca0486",
+                "url": "https://api.github.com/repos/symfony/runtime/zipball/da8ebb6c2ca375c19a915527fb1b20332b668151",
+                "reference": "da8ebb6c2ca375c19a915527fb1b20332b668151",
                 "shasum": ""
             },
             "require": {
@@ -6390,7 +6391,7 @@
             "description": "Enables decoupling PHP applications from global state",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/runtime/tree/v5.4.19"
+                "source": "https://github.com/symfony/runtime/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -6406,7 +6407,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T16:47:48+00:00"
+            "time": "2023-01-24T14:02:46+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6493,16 +6494,16 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "bd2b066090fd6a67039371098fa25a84cb2679ec"
+                "reference": "f83692cd869a6f2391691d40a01e8acb89e76fee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/bd2b066090fd6a67039371098fa25a84cb2679ec",
-                "reference": "bd2b066090fd6a67039371098fa25a84cb2679ec",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/f83692cd869a6f2391691d40a01e8acb89e76fee",
+                "reference": "f83692cd869a6f2391691d40a01e8acb89e76fee",
                 "shasum": ""
             },
             "require": {
@@ -6535,7 +6536,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.4.19"
+                "source": "https://github.com/symfony/stopwatch/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -6551,20 +6552,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-14T08:03:56+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "0a01071610fd861cc160dfb7e2682ceec66064cb"
+                "reference": "edac10d167b78b1d90f46a80320d632de0bd9f2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/0a01071610fd861cc160dfb7e2682ceec66064cb",
-                "reference": "0a01071610fd861cc160dfb7e2682ceec66064cb",
+                "url": "https://api.github.com/repos/symfony/string/zipball/edac10d167b78b1d90f46a80320d632de0bd9f2f",
+                "reference": "edac10d167b78b1d90f46a80320d632de0bd9f2f",
                 "shasum": ""
             },
             "require": {
@@ -6621,7 +6622,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.19"
+                "source": "https://github.com/symfony/string/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -6637,20 +6638,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-22T08:00:55+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "83d487b13b7fb4c0a6ad079f4e4c9b4525e1b695"
+                "reference": "6996affeea65705086939894b77110e9a7f80874"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/83d487b13b7fb4c0a6ad079f4e4c9b4525e1b695",
-                "reference": "83d487b13b7fb4c0a6ad079f4e4c9b4525e1b695",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/6996affeea65705086939894b77110e9a7f80874",
+                "reference": "6996affeea65705086939894b77110e9a7f80874",
                 "shasum": ""
             },
             "require": {
@@ -6718,7 +6719,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v5.4.19"
+                "source": "https://github.com/symfony/translation/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -6734,7 +6735,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-21T19:46:44+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -6816,16 +6817,16 @@
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "0526188cb886be64351454826fecc6d35356eaf1"
+                "reference": "bd1cad2b2fea04e24966c8b1f2b00710ebf26008"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/0526188cb886be64351454826fecc6d35356eaf1",
-                "reference": "0526188cb886be64351454826fecc6d35356eaf1",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/bd1cad2b2fea04e24966c8b1f2b00710ebf26008",
+                "reference": "bd1cad2b2fea04e24966c8b1f2b00710ebf26008",
                 "shasum": ""
             },
             "require": {
@@ -6838,7 +6839,7 @@
                 "phpdocumentor/reflection-docblock": "<3.2.2",
                 "phpdocumentor/type-resolver": "<1.4.0",
                 "symfony/console": "<5.3",
-                "symfony/form": "<5.3",
+                "symfony/form": "<5.4.21|>=6,<6.2.7",
                 "symfony/http-foundation": "<5.3",
                 "symfony/http-kernel": "<4.4",
                 "symfony/translation": "<5.2",
@@ -6853,7 +6854,7 @@
                 "symfony/dependency-injection": "^4.4|^5.0|^6.0",
                 "symfony/expression-language": "^4.4|^5.0|^6.0",
                 "symfony/finder": "^4.4|^5.0|^6.0",
-                "symfony/form": "^5.3|^6.0",
+                "symfony/form": "^5.4.21|^6.2.7",
                 "symfony/http-foundation": "^5.3|^6.0",
                 "symfony/http-kernel": "^4.4|^5.0|^6.0",
                 "symfony/intl": "^4.4|^5.0|^6.0",
@@ -6917,7 +6918,7 @@
             "description": "Provides integration for Twig with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/twig-bridge/tree/v5.4.19"
+                "source": "https://github.com/symfony/twig-bridge/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -6933,20 +6934,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-09T05:43:46+00:00"
+            "time": "2023-02-23T17:08:09+00:00"
         },
         {
             "name": "symfony/twig-bundle",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bundle.git",
-                "reference": "286bd9e38b9bcb142f1eda0a75b0bbeb49ff34bd"
+                "reference": "875d0edfc8df7505c1993419882c4071fc28c477"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bundle/zipball/286bd9e38b9bcb142f1eda0a75b0bbeb49ff34bd",
-                "reference": "286bd9e38b9bcb142f1eda0a75b0bbeb49ff34bd",
+                "url": "https://api.github.com/repos/symfony/twig-bundle/zipball/875d0edfc8df7505c1993419882c4071fc28c477",
+                "reference": "875d0edfc8df7505c1993419882c4071fc28c477",
                 "shasum": ""
             },
             "require": {
@@ -7006,7 +7007,7 @@
             "description": "Provides a tight integration of Twig into the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/twig-bundle/tree/v5.4.19"
+                "source": "https://github.com/symfony/twig-bundle/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -7022,20 +7023,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-14T08:03:56+00:00"
         },
         {
             "name": "symfony/uid",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "962c08ab8e0621e966ff1a19d398308b34f24aa2"
+                "reference": "a30744506976aafc807ccb0d4f95865c0a690d02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/962c08ab8e0621e966ff1a19d398308b34f24aa2",
-                "reference": "962c08ab8e0621e966ff1a19d398308b34f24aa2",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/a30744506976aafc807ccb0d4f95865c0a690d02",
+                "reference": "a30744506976aafc807ccb0d4f95865c0a690d02",
                 "shasum": ""
             },
             "require": {
@@ -7080,7 +7081,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v5.4.19"
+                "source": "https://github.com/symfony/uid/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -7096,20 +7097,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-14T08:03:56+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "2944bbc23f5f8da2b962fbcbf7c4a6109b2f4b7b"
+                "reference": "6c5ac3a1be8b849d59a1a77877ee110e1b55eb74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/2944bbc23f5f8da2b962fbcbf7c4a6109b2f4b7b",
-                "reference": "2944bbc23f5f8da2b962fbcbf7c4a6109b2f4b7b",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/6c5ac3a1be8b849d59a1a77877ee110e1b55eb74",
+                "reference": "6c5ac3a1be8b849d59a1a77877ee110e1b55eb74",
                 "shasum": ""
             },
             "require": {
@@ -7169,7 +7170,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.4.19"
+                "source": "https://github.com/symfony/var-dumper/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -7185,28 +7186,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-16T10:52:33+00:00"
+            "time": "2023-02-23T10:00:28+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v5.4.19",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "2a1d06fcf2b30829d6c01dae8e6e188424d1f8f6"
+                "reference": "86062dd0103530e151588c8f60f5b85a139f1442"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/2a1d06fcf2b30829d6c01dae8e6e188424d1f8f6",
-                "reference": "2a1d06fcf2b30829d6c01dae8e6e188424d1f8f6",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/86062dd0103530e151588c8f60f5b85a139f1442",
+                "reference": "86062dd0103530e151588c8f60f5b85a139f1442",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "symfony/var-dumper": "^4.4.9|^5.0.9|^6.0"
+                "symfony/var-dumper": "^5.4|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -7239,10 +7239,12 @@
                 "export",
                 "hydrate",
                 "instantiate",
+                "lazy loading",
+                "proxy",
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v5.4.19"
+                "source": "https://github.com/symfony/var-exporter/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -7258,20 +7260,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-12T16:39:29+00:00"
+            "time": "2023-02-24T10:42:00+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "71c05db20cb9b54d381a28255f17580e2b7e36a5"
+                "reference": "3713e20d93e46e681e51605d213027e48dab3469"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/71c05db20cb9b54d381a28255f17580e2b7e36a5",
-                "reference": "71c05db20cb9b54d381a28255f17580e2b7e36a5",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/3713e20d93e46e681e51605d213027e48dab3469",
+                "reference": "3713e20d93e46e681e51605d213027e48dab3469",
                 "shasum": ""
             },
             "require": {
@@ -7317,7 +7319,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.19"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -7333,20 +7335,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-10T18:51:14+00:00"
+            "time": "2023-02-21T19:46:44+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v3.5.0",
+            "version": "v3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "3ffcf4b7d890770466da3b2666f82ac054e7ec72"
+                "reference": "a6e0510cc793912b451fd40ab983a1d28f611c15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3ffcf4b7d890770466da3b2666f82ac054e7ec72",
-                "reference": "3ffcf4b7d890770466da3b2666f82ac054e7ec72",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a6e0510cc793912b451fd40ab983a1d28f611c15",
+                "reference": "a6e0510cc793912b451fd40ab983a1d28f611c15",
                 "shasum": ""
             },
             "require": {
@@ -7397,7 +7399,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.5.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.5.1"
             },
             "funding": [
                 {
@@ -7409,7 +7411,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-27T12:28:18+00:00"
+            "time": "2023-02-08T07:49:20+00:00"
         }
     ],
     "packages-dev": [
@@ -7716,16 +7718,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.3",
+            "version": "v4.15.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039"
+                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/570e980a201d8ed0236b0a62ddf2c9cbb2034039",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
                 "shasum": ""
             },
             "require": {
@@ -7766,9 +7768,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.3"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
             },
-            "time": "2023-01-16T22:05:37+00:00"
+            "time": "2023-03-05T19:49:14+00:00"
         },
         {
             "name": "phpstan/extension-installer",
@@ -7816,16 +7818,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.9.14",
+            "version": "1.10.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e5fcc96289cf737304286a9b505fbed091f02e58"
+                "reference": "b10ceb526d9607903c5b2673f1fc8775dbe48975"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e5fcc96289cf737304286a9b505fbed091f02e58",
-                "reference": "e5fcc96289cf737304286a9b505fbed091f02e58",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b10ceb526d9607903c5b2673f1fc8775dbe48975",
+                "reference": "b10ceb526d9607903c5b2673f1fc8775dbe48975",
                 "shasum": ""
             },
             "require": {
@@ -7854,8 +7856,11 @@
                 "static analysis"
             ],
             "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.9.14"
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
             },
             "funding": [
                 {
@@ -7871,25 +7876,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-19T10:47:09+00:00"
+            "time": "2023-03-16T15:24:20+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",
-            "version": "1.3.32",
+            "version": "1.3.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-doctrine.git",
-                "reference": "4534559a8c08ab3648c6fa09289478780e190ae7"
+                "reference": "62bd362b432fe29e175168689510ddd927b698f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/4534559a8c08ab3648c6fa09289478780e190ae7",
-                "reference": "4534559a8c08ab3648c6fa09289478780e190ae7",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/62bd362b432fe29e175168689510ddd927b698f8",
+                "reference": "62bd362b432fe29e175168689510ddd927b698f8",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.9.11"
+                "phpstan/phpstan": "^1.10"
             },
             "conflict": {
                 "doctrine/collections": "<1.0",
@@ -7939,28 +7944,28 @@
             "description": "Doctrine extensions for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
-                "source": "https://github.com/phpstan/phpstan-doctrine/tree/1.3.32"
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/1.3.37"
             },
-            "time": "2023-01-12T13:39:08+00:00"
+            "time": "2023-03-17T14:57:03+00:00"
         },
         {
             "name": "phpstan/phpstan-symfony",
-            "version": "1.2.20",
+            "version": "1.2.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-symfony.git",
-                "reference": "d89a521e7e31822409bf37f70691f7a12a6e7d76"
+                "reference": "8a8d0538ca943b20beda7e9799e14fb3683262d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/d89a521e7e31822409bf37f70691f7a12a6e7d76",
-                "reference": "d89a521e7e31822409bf37f70691f7a12a6e7d76",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/8a8d0538ca943b20beda7e9799e14fb3683262d4",
+                "reference": "8a8d0538ca943b20beda7e9799e14fb3683262d4",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.9.1"
+                "phpstan/phpstan": "^1.9.4"
             },
             "conflict": {
                 "symfony/framework-bundle": "<3.0"
@@ -8010,22 +8015,22 @@
             "description": "Symfony Framework extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-symfony/issues",
-                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.2.20"
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.2.23"
             },
-            "time": "2023-01-15T12:28:31+00:00"
+            "time": "2023-02-06T10:42:02+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -8061,14 +8066,15 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "symfony/maker-bundle",
@@ -8165,16 +8171,16 @@
         },
         {
             "name": "symfony/web-profiler-bundle",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/web-profiler-bundle.git",
-                "reference": "cd83822071f2bc05583af1e53c1bc46be625a56d"
+                "reference": "a83337a813d1398789bf4190a56dc3c4d8cc4d93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/cd83822071f2bc05583af1e53c1bc46be625a56d",
-                "reference": "cd83822071f2bc05583af1e53c1bc46be625a56d",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/a83337a813d1398789bf4190a56dc3c4d8cc4d93",
+                "reference": "a83337a813d1398789bf4190a56dc3c4d8cc4d93",
                 "shasum": ""
             },
             "require": {
@@ -8225,7 +8231,7 @@
             "description": "Provides a development tool that gives detailed information about the execution of any request",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/web-profiler-bundle/tree/v5.4.19"
+                "source": "https://github.com/symfony/web-profiler-bundle/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -8241,7 +8247,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:32:19+00:00"
+            "time": "2023-02-17T16:59:45+00:00"
         }
     ],
     "aliases": [],

--- a/migrations/Version20230320211248.php
+++ b/migrations/Version20230320211248.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230320211248 extends MSPMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add unique column api_batch_guid to api_batch table';
+    }
+
+    protected function getDatabaseType(): ?MSPDatabaseType
+    {
+        return new MSPDatabaseType(MSPDatabaseType::DATABASE_TYPE_GAME_SESSION);
+    }
+
+    protected function onUp(Schema $schema): void
+    {
+        // phpcs:ignoreFile Generic.Files.LineLength.TooLong
+        $this->addSql("ALTER TABLE `api_batch` ADD `api_batch_guid` char(36) COLLATE 'utf8mb4_general_ci' NOT NULL AFTER `api_batch_user_id`");
+        $this->addSql("ALTER TABLE `api_batch` ADD UNIQUE `api_batch_guid` (`api_batch_guid`)");
+    }
+
+    protected function onDown(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE `api_batch` DROP INDEX `api_batch_guid`");
+        $this->addSql("ALTER TABLE `api_batch` DROP `api_batch_guid`");
+    }
+}

--- a/src/Domain/WsServer/ExecuteBatchRejection.php
+++ b/src/Domain/WsServer/ExecuteBatchRejection.php
@@ -4,32 +4,25 @@ namespace App\Domain\WsServer;
 
 class ExecuteBatchRejection
 {
-    private int $batchId;
+    private string $batchGuid;
+    private mixed $reason;
 
     /**
-     * @var mixed
-     */
-    private $reason;
-
-    /**
-     * @param int $batchId
+     * @param string $batchGuid
      * @param mixed $reason
      */
-    public function __construct(int $batchId, $reason)
+    public function __construct(string $batchGuid, mixed $reason)
     {
-        $this->batchId = $batchId;
+        $this->batchGuid = $batchGuid;
         $this->reason = $reason;
     }
 
-    public function getBatchId(): int
+    public function getBatchGuid(): string
     {
-        return $this->batchId;
+        return $this->batchGuid;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getReason()
+    public function getReason(): mixed
     {
         return $this->reason;
     }

--- a/src/Domain/WsServer/Plugins/ExecuteBatchesWsServerPlugin.php
+++ b/src/Domain/WsServer/Plugins/ExecuteBatchesWsServerPlugin.php
@@ -9,6 +9,7 @@ use App\Domain\WsServer\ClientDisconnectedException;
 use App\Domain\WsServer\ClientHeaderKeys;
 use App\Domain\WsServer\ExecuteBatchRejection;
 use App\Domain\WsServer\WsServerEventDispatcherInterface;
+use Doctrine\DBAL\ArrayParameterType;
 use Drift\DBAL\Result;
 use Exception;
 use React\Promise\Deferred;
@@ -148,13 +149,13 @@ class ExecuteBatchesWsServerPlugin extends Plugin
                             throw $e;
                         }
 
-                        $batchId = key($batchResultContainer);
+                        $batchGuid = key($batchResultContainer);
                         $batchResult = current($batchResultContainer);
 
                         $data = [
                             'header_type' => 'Batch/ExecuteBatch',
                             'header_data' => [
-                                'batch_id' => $batchId,
+                                'batch_guid' => $batchGuid,
                             ],
                             'success' => true,
                             'message' => null,
@@ -165,12 +166,12 @@ class ExecuteBatchesWsServerPlugin extends Plugin
                             $data
                         );
 
-                        return $this->setBatchToCommunicated($connResourceId, $batchId, $batchResultContainer);
+                        return $this->setBatchToCommunicated($connResourceId, $batchGuid, $batchResultContainer);
                     },
                     function ($rejection) use ($connResourceId) {
                         $reason = $rejection;
                         if ($rejection instanceof ExecuteBatchRejection) {
-                            $batchId = $rejection->getBatchId();
+                            $batchGuid = $rejection->getBatchGuid();
                             $reason = $rejection->getReason();
                             $message = '';
                             if (is_string($reason)) {
@@ -188,7 +189,7 @@ class ExecuteBatchesWsServerPlugin extends Plugin
                             $data = [
                                 'header_type' => 'Batch/ExecuteBatch',
                                 'header_data' => [
-                                    'batch_id' => $batchId,
+                                    'batch_guid' => $batchGuid,
                                 ],
                                 'success' => false,
                                 'message' => $message ?: 'Unknown reason',
@@ -199,7 +200,7 @@ class ExecuteBatchesWsServerPlugin extends Plugin
                                 ->sendAsJson($data);
                             return $this->setBatchToCommunicated(
                                 $connResourceId,
-                                $batchId,
+                                $batchGuid,
                                 [] // do not propagate rejection, just resolve to empty batch results
                             );
                         }
@@ -214,11 +215,11 @@ class ExecuteBatchesWsServerPlugin extends Plugin
     /**
      * @throws Exception
      */
-    private function setBatchToCommunicated(int $connResourceId, int $batchId, $value = null): PromiseInterface
+    private function setBatchToCommunicated(int $connResourceId, string $batchGuid, $value = null): PromiseInterface
     {
         // set batch as "communicated"
         $deferred = new Deferred();
-        $this->getBatch($connResourceId)->setCommunicated($batchId)
+        $this->getBatch($connResourceId)->setCommunicated($batchGuid)
             ->done(
                 function (/* Result $result */) use ($deferred, $value) {
                     $deferred->resolve($value);
@@ -264,7 +265,7 @@ class ExecuteBatchesWsServerPlugin extends Plugin
         $qb = $connection->createQueryBuilder();
         return $connection->query(
             $qb
-                ->select('b.api_batch_id', 'b.api_batch_user_id', 'b.api_batch_country_id')
+                ->select('b.api_batch_guid', 'b.api_batch_user_id', 'b.api_batch_country_id')
                 ->from('api_batch', 'b')
                 ->where(
                     $qb->expr()->and(
@@ -276,7 +277,7 @@ class ExecuteBatchesWsServerPlugin extends Plugin
         )
         ->then(function (Result $result) use ($connection) {
             $batches = collect($result->fetchAllRows() ?? [])
-                ->keyBy('api_batch_id')
+                ->keyBy('api_batch_guid')
                 ->all();
             if (empty($batches)) {
                 return [];
@@ -286,7 +287,10 @@ class ExecuteBatchesWsServerPlugin extends Plugin
                 $qb
                     ->update('api_batch', 'b')
                     ->set('b.api_batch_state', $qb->createPositionalParameter('Failed'))
-                    ->where($qb->expr()->in('b.api_batch_id', array_keys($batches)))
+                    ->where($qb->expr()->in(
+                        'b.api_batch_guid',
+                        $qb->createPositionalParameter($batches, ArrayParameterType::STRING)
+                    ))
             )
             ->then(function (/* Result $result */) use ($batches) {
                 // find client connections matching these batches if any


### PR DESCRIPTION
* No more separate StartBatch/AddToBatch api calls. They have been merged towards ExecuteBatch api call.
* added batch guid to startBatch(), which is inserted in the api_batch table.
* adapted addToBatch to insert for multiple "requests"
* Extended ExecuteBatch to start the batch , add the (sub)requests using addToBatch(), and then start the execution of the batch
* using batch guid for queries/classes instead of the -id
* Commented code in test.batch.php since it used the StartBatch/AddToBatch api calls, needs rewriting if we still want to use it
* Added db migration to add unique column api_batch_guid to api_batch table.
* composer update
* code style fixes

## Checklist before requesting a review
- [ ] I am using the Jira issue number in the commit message.
- [ ] The branch is named as the Jira issue number.
