### PR TITLE
MSP-4528 fix recreate game session on end state in demo mode

### DIFF
--- a/ServerManager/api/addGameSession.php
+++ b/ServerManager/api/addGameSession.php
@@ -13,7 +13,6 @@ $user = new User();
 
 $user->hasToBeLoggedIn();
 
-$gamesession->setJWT($_POST['jwt'] ?? "");
 $gamesession->processPostedVars();
 $gamesession->id = -1;
 $gamesession->game_server_id = 1;

--- a/ServerManager/api/browseGeoServer.php
+++ b/ServerManager/api/browseGeoServer.php
@@ -12,8 +12,6 @@ $user = new User();
 
 $user->hasToBeLoggedIn();
 
-$geoserver->setJWT($_POST['jwt'] ?? "");
-
 $api->setPayload(["geoserverslist" => $geoserver->getList()]);
 $api->setStatusSuccess();
 $api->Return();

--- a/ServerManager/api/editGameSession.php
+++ b/ServerManager/api/editGameSession.php
@@ -16,8 +16,6 @@ $user->hasToBeLoggedIn();
 $gamesession->id = $_POST["session_id"] ?? "";
 $gamesession->get();
 
-// this endpoint will need the JWT in case of recreate
-$gamesession->setJWT($_POST['jwt'] ?? "");
 // now optionally change all the object vars
 $gamesession->processPostedVars();
 

--- a/ServerManager/api/editServerManager.php
+++ b/ServerManager/api/editServerManager.php
@@ -13,9 +13,6 @@ $user = new User();
 $user->hasToBeLoggedIn();
 
 $servermanager->get();
-
-// optionally change all the object vars
-$servermanager->setJWT($_POST['jwt'] ?? "");
 $servermanager->processPostedVars();
 
 // ready to do final actual update

--- a/ServerManager/classes/GameSession.php
+++ b/ServerManager/classes/GameSession.php
@@ -185,7 +185,6 @@ class GameSession extends Base
     public function sendCreateRequest($allow_recreate = 0)
     {
         $geoserver = new GeoServer();
-        $geoserver->setJWT($this->getJWT());
         $geoserver->id = $this->game_geoserver_id;
         $geoserver->get();
 

--- a/ServerManager/classes/GeoServer.php
+++ b/ServerManager/classes/GeoServer.php
@@ -85,7 +85,7 @@ class GeoServer extends Base
             }
         }
 
-        if (1 == $this->id && null !== $this->jwt) {
+        if (1 == $this->id && null !== $this->getJWT()) {
             $this->retrievePublic(); // this will get the BUas public GeoServer address and credentials
         }
 


### PR DESCRIPTION
Issue was an endless loop calling getJWT:

* removed setJWT() , and the jwt property of GameSession class. Just store and get the token from the session using Session::get / ::put
* added hasJWT().
* the actual fix in Base::callAuthoriser: only call getJWT is hasJWT is true to prevent endless loop. E.g. getJWT calls postCallAuthoriser with "login_check" calling callAuthoriser, so callAuthoriser should not call getJWT if there is no token
