### PR TITLE
fix url scheme based on env variable URL_WEB_SERVER_SCHEME

### DIFF
--- a/api/v1/GameSession.php
+++ b/api/v1/GameSession.php
@@ -79,7 +79,7 @@ class GameSession extends Base
 
         $_SERVER['HTTPS'] ??= 'off';
         /** @noinspection HttpUrlsUsage */
-        $protocol = ($_SERVER['HTTPS'] == 'on') ? "https://" : "http://";
+        $protocol = ($_SERVER['HTTPS'] == 'on') ? "https://" : ($_ENV['URL_WEB_SERVER_SCHEME'] ?? "http://");
 
         $connection = ConnectionManager::getInstance()->getCachedAsyncServerManagerDbConnection(Loop::get());
         return $connection->query(
@@ -125,7 +125,7 @@ class GameSession extends Base
         $serverName = $_SERVER["SERVER_NAME"] ?? gethostname();
 
         /** @noinspection HttpUrlsUsage */
-        $protocol = isset($_SERVER['HTTPS'])? "https://" : "http://";
+        $protocol = isset($_SERVER['HTTPS'])? "https://" : ($_ENV['URL_WEB_SERVER_SCHEME'] ?? "http://");
         $apiFolder = "/ServerManager/api/";
         $dbConfig = Config::GetInstance()->DatabaseConfig();
         $temporaryConnection = Database::CreateTemporaryDBConnection(


### PR DESCRIPTION
fixes usage of wrong http scheme with port 443 based on env variables. 
(went wrong for websocket server on production)