### PR TITLE
added a "start simulations" button to the Symfony web profiler bar in the MSP section

### DIFF
--- a/api/v1/Game.php
+++ b/api/v1/Game.php
@@ -719,22 +719,28 @@ class Game extends Base
                 $responseContent = $response->getBody()->getContents();
                 $decodedResponse = json_decode($responseContent, true);
                 if (json_last_error() !== JSON_ERROR_NONE) {
-                    return $log->postEvent(
+                    $funcArgs = [
                         "Watchdog",
                         Log::ERROR,
                         "Received invalid response from watchdog. Response: \"".$responseContent."\"",
                         "changeWatchdogState()"
-                    );
+                    ];
+                    return $log->postEvent(...$funcArgs)->then(function () use ($funcArgs) {
+                        return $funcArgs;
+                    });
                 }
 
                 if ($decodedResponse["success"] != 1) {
-                    return $log->postEvent(
+                    $funcArgs = [
                         "Watchdog",
                         Log::ERROR,
                         "Watchdog responded with failure to change game state request. Response: \"".
                         $decodedResponse["message"]."\"",
                         "changeWatchdogState()"
-                    );
+                    ];
+                    return $log->postEvent(...$funcArgs)->then(function () use ($funcArgs) {
+                        return $funcArgs;
+                    });
                 }
                 return resolveOnFutureTick(new Deferred(), $decodedResponse)->promise();
             });

--- a/api/v1/GameSession.php
+++ b/api/v1/GameSession.php
@@ -74,7 +74,7 @@ class GameSession extends Base
             $deferred = new Deferred();
             return resolveOnFutureTick($deferred, $GLOBALS['RequestApiRoot'])->promise();
         }
-        $apiRoot = preg_replace('/(.*)\/api\/(.*)/', '$1/', $_SERVER["REQUEST_URI"]);
+        $apiRoot = preg_replace('/(.*)\/(api|_profiler)\/(.*)/', '$1/', $_SERVER["REQUEST_URI"]);
         $apiRoot = str_replace("//", "/", $apiRoot);
 
         $_SERVER['HTTPS'] ??= 'off';

--- a/config-symfony5.4/routes/web_profiler.yaml
+++ b/config-symfony5.4/routes/web_profiler.yaml
@@ -3,6 +3,12 @@ when@dev:
         resource: '@WebProfilerBundle/Resources/config/routing/wdt.xml'
         prefix: /_wdt
 
+    web_profiler_msp_start_simulations:
+        path: /{session}/_profiler/msp_start_simulations
+        controller: App\DataCollector\MSPDataCollector::startSimulations
+        requirements:
+            session: '\d+'
+
     web_profiler_profiler:
         resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
         prefix: /_profiler

--- a/config-symfony5.4/services.yaml
+++ b/config-symfony5.4/services.yaml
@@ -55,3 +55,4 @@ when@dev:
                     name: data_collector
                     id: 'App\DataCollector\MSPDataCollector'
                     template: 'data_collector/msp.html.twig'
+                - 'controller.service_arguments'

--- a/src/DataCollector/MSPDataCollector.php
+++ b/src/DataCollector/MSPDataCollector.php
@@ -2,10 +2,15 @@
 
 namespace App\DataCollector;
 
+use App\Domain\API\APIHelper;
+use App\Domain\API\v1\Game;
+use App\Domain\Services\ConnectionManager;
+use App\Domain\Services\SymfonyToLegacyHelper;
 use Exception;
 use Symfony\Bundle\FrameworkBundle\DataCollector\AbstractDataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use function App\await;
 
 class MSPDataCollector extends AbstractDataCollector
 {
@@ -32,5 +37,25 @@ class MSPDataCollector extends AbstractDataCollector
     public function getData(): array
     {
         return $this->data;
+    }
+
+    public function startSimulations(
+        int $session,
+        // below is required by legacy to be auto-wire, has its own ::getInstance()
+        SymfonyToLegacyHelper $helper
+    ): Response {
+        $qb = ConnectionManager::getInstance()->getCachedGameSessionDbConnection($session)->createQueryBuilder();
+        try {
+            $gameState = $qb->select('game_state')->from('game')->fetchOne();
+        } catch (\Exception $e) {
+            return new Response($e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+        $game = new Game();
+        $game->setGameSessionId($session);
+        if (null === $promise = $game->changeWatchdogState($gameState)) {
+            return new Response('Could not change watchdog state', Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+        $arrResult = await($promise);
+        return new Response(json_encode($arrResult));
     }
 }

--- a/templates/data_collector/msp.html.twig
+++ b/templates/data_collector/msp.html.twig
@@ -12,12 +12,23 @@
                 <span class="sf-toolbar-status">{{ value|slice(0,30) }}... {% if value|length > 30 %}+{{ value|slice(30)|length }} chars{% endif %}</span>
             </div>
         {% endfor %}
+        <div class="sf-toolbar-info-piece">
+            <b><label for="session_id">Session ID:</label> <input id="session_id" type="number" value="1" style="width: 60px" /></b>
+            <button id="simulations_start" type="button" onClick="(function(){
+     $.ajax(
+        '/' + document.getElementById('session_id').value + '/_profiler/msp_start_simulations',
+        function(result){
+           console.log(result);
+        }
+     );
+     return false;
+})();return false;">Start simulations</button>
+        </div>
     {% endset %}
 
     {# the 'link' value set to 'false' means that this panel doesn't
        show a section in the web profiler #}
     {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: true }) }}
-
 {% endblock %}
 
 {% block menu %}
@@ -31,7 +42,7 @@
 {% block panel %}
     <h2>MSP Challenge</h2>
     <table>
-         {% for name, value in collector.data %}
+        {% for name, value in collector.data %}
         <tr>
             <td>{{ name }}</td>
             <td>{{ value }}</td>


### PR DESCRIPTION
![image](https://github.com/BredaUniversityResearch/MSPChallenge-Server/assets/89514754/04f6a06c-d895-44b4-baa7-8d0a0cfbd450)

such that you can just start the simulations for the current game session state, so without the need to change the game session state