### PR TITLE
fixed "todo": do another watchdog alive test, with a repeat and failure mechanism

### DIFF
--- a/api/v1/Game.php
+++ b/api/v1/Game.php
@@ -792,6 +792,7 @@ class Game extends Base
             ->then(function (ResponseInterface $response) {
                 $log = new Log();
                 $this->asyncDataTransferTo($log);
+                $log->setAsync(true); // force async in this context
 
                 $responseContent = $response->getBody()->getContents();
                 $decodedResponse = json_decode($responseContent, true);


### PR DESCRIPTION
Fixes issue MSP-4605 , see `$log->setAsync(true);` 