### PR TITLE
POV-437

### DIFF
--- a/.env
+++ b/.env
@@ -30,7 +30,7 @@ DATABASE_USER=root
 # for dev Windows XAMPP, if password is set, do not forget to run: "mysqladmin -u root password" to change the password
 DATABASE_PASSWORD=
 MY2_PASSWORD=euK@h89j6F5V
-DATABASE_SERVER_VERSION=mariadb-10.4.25
+DATABASE_SERVER_VERSION=mariadb-10.5.23
 DATABASE_CHARSET=utf8mb4
 # Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml

--- a/.env
+++ b/.env
@@ -30,7 +30,7 @@ DATABASE_USER=root
 # for dev Windows XAMPP, if password is set, do not forget to run: "mysqladmin -u root password" to change the password
 DATABASE_PASSWORD=
 MY2_PASSWORD=euK@h89j6F5V
-DATABASE_SERVER_VERSION=mariadb-10.5.23
+DATABASE_SERVER_VERSION=mariadb-10.6.16
 DATABASE_CHARSET=utf8mb4
 # Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,3 @@ phpstan.neon
 /config/jwt/*.pem
 /config-symfony5.4/jwt/*.pem
 ###< lexik/jwt-authentication-bundle ###
-
-# default output directory for command bin/console app:create-pov-config
-POV/

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ phpstan.neon
 /config/jwt/*.pem
 /config-symfony5.4/jwt/*.pem
 ###< lexik/jwt-authentication-bundle ###
+
+# default output directory for command bin/console app:create-pov-config
+POV/

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN set -eux; \
 		opcache \
     	zip \
         pcntl \
+        imagick \
     ;
 
 # if you want to debug on prod, enable below lines:
@@ -162,7 +163,7 @@ FROM caddy_base AS caddy_prod
 
 COPY --from=php_prod --link /srv/app/public public/
 
-FROM mariadb:10.5.23 AS mariadb_base
+FROM mariadb:10.6.16 AS mariadb_base
 FROM blackfire/blackfire:2 AS blackfire_base
 FROM adminer AS adminer_base
 FROM mitmproxy/mitmproxy:9.0.1 as mitmproxy_base

--- a/Dockerfile
+++ b/Dockerfile
@@ -162,7 +162,7 @@ FROM caddy_base AS caddy_prod
 
 COPY --from=php_prod --link /srv/app/public public/
 
-FROM mariadb:10.4.25 AS mariadb_base
+FROM mariadb:10.5.23 AS mariadb_base
 FROM blackfire/blackfire:2 AS blackfire_base
 FROM adminer AS adminer_base
 FROM mitmproxy/mitmproxy:9.0.1 as mitmproxy_base

--- a/POV/.gitignore
+++ b/POV/.gitignore
@@ -1,0 +1,5 @@
+# default output directory for command bin/console app:create-pov-config
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/api/v1/GameSession.php
+++ b/api/v1/GameSession.php
@@ -714,6 +714,7 @@ class GameSession extends Base
     // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     private static function RemoveDirectory(string $dir): void
     {
+        // todo: use Util::removeDirectory() instead ??
         try {
             $it = new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS);
             $files = new RecursiveIteratorIterator(

--- a/composer-symfony5.4.json
+++ b/composer-symfony5.4.json
@@ -8,6 +8,7 @@
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-iconv": "*",
+        "ext-imagick": "*",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-openssl": "*",

--- a/config-symfony5.4/routes.yaml
+++ b/config-symfony5.4/routes.yaml
@@ -17,17 +17,23 @@ apidoc:
 session_api_game_create_pov_config:
   path: '/{sessionId}/api/Game/CreatePOVConfig'
   controller: App\Controller\SessionAPI\GameController::createPOVConfig
-  #methods: ['POST']
+  methods: ['POST']
   requirements:
     sessionId: '\d+'
 
 session_api_user_controller_requestsession:
   path: '/{sessionId}/api/User/RequestSession'
   controller: App\Controller\SessionAPI\UserController::requestSession
+  methods: ['POST']
+  requirements:
+    sessionId: '\d+'
 
 session_api_user_controller_requesttoken:
   path: '/{sessionId}/api/User/RequestToken'
   controller: App\Controller\SessionAPI\UserController::requestToken
+  methods: ['POST']
+  requirements:
+    sessionId: '\d+'
 
 # per session support
 # RewriteRule ^([0-9]+)/api/(.*)$	index.php?session=$1&query=$2 [NC,L]

--- a/config-symfony5.4/routes.yaml
+++ b/config-symfony5.4/routes.yaml
@@ -14,6 +14,13 @@ apidoc:
   requirements:
     anything: '.*'
 
+session_api_game_create_pov_config:
+  path: '/{sessionId}/api/Game/CreatePOVConfig'
+  controller: App\Controller\SessionAPI\GameController::createPOVConfig
+  #methods: ['POST']
+  requirements:
+    sessionId: '\d+'
+
 session_api_user_controller_requestsession:
   path: '/{sessionId}/api/User/RequestSession'
   controller: App\Controller\SessionAPI\UserController::requestSession

--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -66,6 +66,8 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX session_archive
 	setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var
 	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var
+	setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX POV
+	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX POV
 	chmod 777 simulations/alpine.3.17-x64/MSW
 	chmod 777 simulations/alpine.3.17-x64/MEL
 	chmod 777 simulations/alpine.3.17-x64/SEL

--- a/migrations/Version20221114201818.php
+++ b/migrations/Version20221114201818.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\DBAL\Schema\SchemaException;
-use Doctrine\Migrations\AbstractMigration;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/migrations/Version20230201140525.php
+++ b/migrations/Version20230201140525.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/migrations/Version20230202092830.php
+++ b/migrations/Version20230202092830.php
@@ -9,7 +9,6 @@ use App\Domain\API\v1\PolicyType;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\Migrations\AbstractMigration;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/migrations/Version20230206150749.php
+++ b/migrations/Version20230206150749.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/migrations/Version20230209151519.php
+++ b/migrations/Version20230209151519.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/migrations/Version20230320211248.php
+++ b/migrations/Version20230320211248.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/migrations/Version20230830153300.php
+++ b/migrations/Version20230830153300.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
 
 final class Version20230830153300 extends MSPMigration
 {

--- a/migrations/Version20231204154654.php
+++ b/migrations/Version20231204154654.php
@@ -9,11 +9,11 @@ use Doctrine\DBAL\Schema\Schema;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20230202120117 extends MSPMigration
+final class Version20231204154654 extends MSPMigration
 {
     public function getDescription(): string
     {
-        return 'Add unique key to plan_layers\' plan_layer_plan_id, plan_layer_layer_id column pair';
+        return 'Add index to geometry_subtractive column in geometry table';
     }
 
     protected function getDatabaseType(): ?MSPDatabaseType
@@ -23,14 +23,11 @@ final class Version20230202120117 extends MSPMigration
 
     protected function onUp(Schema $schema): void
     {
-        $this->addSql(
-            'ALTER TABLE `plan_layer` ADD UNIQUE `plan_layer_plan_id_plan_layer_layer_id` '.
-            '(`plan_layer_plan_id`, `plan_layer_layer_id`)'
-        );
+        $schema->getTable('geometry')->addIndex(['geometry_subtractive'], 'geometry_subtractive');
     }
 
     protected function onDown(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE `plan_layer` DROP INDEX `plan_layer_plan_id_plan_layer_layer_id`');
+        $schema->getTable('geometry')->dropIndex('geometry_subtractive');
     }
 }

--- a/src/Command/CreatePOVConfigCommand.php
+++ b/src/Command/CreatePOVConfigCommand.php
@@ -49,8 +49,7 @@ class CreatePOVConfigCommand extends Command
                 self::OPT_OUTPUT_DIR,
                 'd',
                 InputOption::VALUE_REQUIRED,
-                'The path to a non-existing or empty output directory. ' .
-                    'Default will be a temporary folder like: ' . ConfigCreator::getDefaultOutputDir($exampleRegion)
+                'The path to output directory. Default is: ' . ConfigCreator::getDefaultOutputBaseDir()
             );
         $this
             ->addOption(
@@ -66,8 +65,8 @@ class CreatePOVConfigCommand extends Command
                 'p',
                 InputOption::VALUE_REQUIRED,
                 'The filename of compressed package file if compression is enabled. ' .
-                    'Default is: ' . ConfigCreator::DEFAULT_COMPRESSED_FILENAME,
-                ConfigCreator::DEFAULT_COMPRESSED_FILENAME
+                    'Default is based on the region coordinates like: ' .
+                        ConfigCreator::getDefaultCompressedFilename($exampleRegion)
             );
         $this->addOption(
             self::OPT_ZIP,

--- a/src/Command/CreatePOVConfigCommand.php
+++ b/src/Command/CreatePOVConfigCommand.php
@@ -3,6 +3,7 @@
 namespace App\Command;
 
 use App\Domain\Services\ConnectionManager;
+use React\MySQL\Exception;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -18,7 +19,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class CreatePOVConfigCommand extends Command
 {
     public function __construct(
-        private readonly ConnectionManager $connectionManager
+        private readonly ConnectionManager $connectionManager,
+        private readonly string $projectDir
     ) {
         parent::__construct();
     }
@@ -60,6 +62,10 @@ class CreatePOVConfigCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+        if (!extension_loaded('imagick')) {
+            $io->error('The imagick extension is not loaded.');
+            return Command::FAILURE;
+        }
         $sessionId = $input->getOption('session-id');
         if (!ctype_digit($sessionId)) {
             $io->error('Session ID must be an integer.');
@@ -89,25 +95,46 @@ class CreatePOVConfigCommand extends Command
         try {
             $result = $connection->executeQuery(<<<'SQL'
 WITH
-  # group geometries by persistent id and give row number based on geometry_id, row number 1 is the latest geometry
+  # group ecology kpis by name and give row number based on month, row number 1 is the latest kpi
+  LatestEcologyKpiStep1 AS (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY kpi_name ORDER BY kpi_month DESC) AS rn
+    FROM
+      kpi
+    WHERE kpi_type = 'ECOLOGY'
+  ),
+  # filter latest ecology kpis, so only with row number 1
+  LatestEcologyKpiFinal AS (
+    SELECT * FROM LatestEcologyKpiStep1 WHERE rn = 1
+  ),
+  # group non-subtractive geometries by persistent id and give row number based on geometry_id,
+  #   row number 1 is the latest geometry
   LatestGeometryStep1 AS (
     SELECT
       *,
       ROW_NUMBER() OVER (PARTITION BY geometry_persistent ORDER BY geometry_id DESC) AS rn
     FROM
       geometry
-    WHERE geometry_deleted = 0 AND geometry_active = 1
+    WHERE geometry_deleted = 0 AND geometry_active = 1 AND geometry_subtractive = 0
   ),
-  # filter out geometries that are not the latest, so only with row number 1
+  # filter latest geometries, so only with row number 1
   LatestGeometryStep2 AS (
     SELECT * FROM LatestGeometryStep1 WHERE rn = 1
+  ),
+  # join all substractive geometries to the latest geometries and aggregate them as a json array "gaps"
+  LatestGeometryStep3 AS (
+    SELECT g.*, JSON_ARRAYAGG(JSON_EXTRACT(gs.geometry_geometry, '$')) AS geometry_gaps
+    FROM LatestGeometryStep2 g
+    LEFT JOIN geometry gs ON gs.geometry_subtractive = g.geometry_id
+    GROUP BY g.geometry_id
   ),
   # filter out geometries that are in a deleted plan, plan needs to be implemented and active
   LatestGeometryFinal AS (
     SELECT
       g.*
     FROM
-      LatestGeometryStep2 g
+      LatestGeometryStep3 g
     LEFT JOIN layer ON layer.layer_id=g.geometry_layer_id
     LEFT JOIN plan_layer ON plan_layer.plan_layer_layer_id=layer.layer_id
     LEFT JOIN plan ON (
@@ -120,12 +147,12 @@ WITH
     GROUP BY g.geometry_persistent
   ),
   # filter out active layers that are not in a plan or in an implemented and active plan
-  LayerFinal AS (
+  LayerStep1 AS (
       SELECT l.*
       FROM layer l
       LEFT JOIN plan_layer pl ON l.layer_id=pl.plan_layer_layer_id
       LEFT JOIN plan p ON p.plan_id=pl.plan_layer_plan_id
-      WHERE l.layer_active = 1 AND  p.plan_id IS NULL OR (p.plan_state IN ('IMPLEMENTED') AND p.plan_active = 1) AND
+      WHERE l.layer_active = 1 AND p.plan_id IS NULL OR (p.plan_state IN ('IMPLEMENTED') AND p.plan_active = 1) AND
       (
         l.layer_geotype IN ('line','point','polygon') OR (
           # if raster, return only if the region overlaps with its bounding box data
@@ -136,6 +163,40 @@ WITH
           AND JSON_EXTRACT(l.layer_raster, '$.boundingbox[1][1]') > :topLeftY
         )
       )
+      GROUP BY l.layer_id
+  ),
+  # include kpi value if layer is an ecology layer and
+  #   extract new data columns from layer_type json data
+  LayerFinal AS (
+      SELECT
+        l.*,
+        k.kpi_value,
+        JSON_ARRAYAGG(JSON_OBJECT(
+          'channel', 'r',
+          'max', t.value,
+          'type', t.id
+        )) AS layer_type_mapping,
+        JSON_ARRAYAGG(JSON_OBJECT(
+          'name', t.display_name,
+          '//material', 'todo'
+        )) AS layer_type_types,
+        MIN(t.value) AS layer_type_value_min,
+        MAX(t.value) AS layer_type_value_max,
+        COUNT(t.id) as layer_type_value_count,
+        CAST((MAX(t.value) / (COUNT(t.id)-1)) as INT) as layer_type_value_step
+      FROM LayerStep1 l
+      INNER JOIN JSON_TABLE(
+        JSON_EXTRACT(l.layer_type, '$.*'),
+          '$[*]' COLUMNS (
+            id for ordinality,
+            display_name VARCHAR(255) PATH '$.displayName',
+            value int PATH '$.value'
+        )
+      ) AS t
+      LEFT JOIN LatestEcologyKpiFinal k ON (
+        l.layer_short != '' AND CONCAT('mel_',LOWER(REPLACE(k.kpi_name,' ','_'))) = l.layer_name
+      )
+      GROUP BY l.layer_id
   ),
   LatestGeometryInRegion AS (
     SELECT *
@@ -149,50 +210,135 @@ SELECT
   JSON_OBJECT(
     'metadata',
     JSON_OBJECT(
-      'data_modified', DATE_FORMAT(NOW(), '%d/%m/%Y')
+      'data_modified', CONCAT(UTC_DATE(), ' ', UTC_TIME())
     ),
     'datamodel',
-    JSON_ARRAYAGG(JSON_EXTRACT(subquery.json_per_layer_type, '$'))
+    JSON_OBJECTAGG(subquery.prop, JSON_EXTRACT(subquery.value, '$.*'))
   ) as json
 FROM (
   SELECT
+    IF(l.layer_geotype = 'raster', 'raster_layers', 'vector_layers') as prop,
     # return the latest geometry for each layer as a json object in POV config json format
-    JSON_OBJECT(
-      IF(l.layer_geotype = 'raster', 'raster_layers', 'vector_layers'),
-        JSON_EXTRACT(JSON_OBJECTAGG(
-          l.layer_id,
-          IF(
-            l.layer_geotype = 'raster',
-            JSON_OBJECT(
-              #'db-layer-id', l.layer_id,
-              'name', l.layer_short,
-              'coordinate0', JSON_EXTRACT(l.layer_raster, '$.boundingbox[0]'),
-              'coordinate1', JSON_EXTRACT(l.layer_raster, '$.boundingbox[1]'),
-              'db-layer-type//mapping//types', JSON_EXTRACT(l.layer_type, '$.*'),
-              'data', CONCAT('RasterMaps/',JSON_UNQUOTE(JSON_EXTRACT(l.layer_raster, '$.url')))
+    JSON_EXTRACT(JSON_OBJECTAGG(
+      l.layer_id,
+      IF(
+        l.layer_geotype = 'raster',
+        JSON_OBJECT(
+          #'db-layer-id', l.layer_id,
+          'name', REPLACE(l.layer_short,'mel_',''),
+          'coordinate0', JSON_EXTRACT(l.layer_raster, '$.boundingbox[0]'),
+          'coordinate1', JSON_EXTRACT(l.layer_raster, '$.boundingbox[1]'),
+          'display_methods', JSON_MERGE_PRESERVE(
+            IF(
+              # detecting a kpi layer
+              l.kpi_value IS NOT NULL,
+              JSON_ARRAY(
+                JSON_OBJECT(
+                  'method', 'DensityFish',
+                  'scale', JSON_OBJECT(
+                    'min_value', 0,
+                    # convert from t/km2 to kg/km2, times 2 since 0.5 is the reference value
+                    'max_value', l.kpi_value * 1000 * 2,
+                    'interpolation', 'lin',
+                    '//model', 'todo, eg: \'Cod\'',
+                    '//unit_mass', 'todo, eg: 10'
+                  )
+                )
+              ),
+              JSON_ARRAY()
             ),
-            JSON_OBJECT(
-              #'db-layer-id', l.layer_id,
-              #'db-geometry-ids', (
-              #   SELECT JSON_ARRAYAGG(JSON_EXTRACT(geometry_id, '$'))
-              #   FROM LatestGeometryInRegion WHERE geometry_Layer_id=l.layer_id
-              # ),
-              'name', l.layer_name,
-#               'display_methods', JSON_OBJECT(
-#                 'stages', JSON_EXTRACT(l.layer_states, '$')
-#               ),
-              'db-types', JSON_EXTRACT(l.layer_type, '$.*'),
-              'data', JSON_OBJECT(
-                'points', (
-                  SELECT JSON_ARRAYAGG(JSON_EXTRACT(geometry_geometry, '$'))
-                  FROM LatestGeometryInRegion WHERE geometry_Layer_id=l.layer_id
-                ),
-                'db-geometry-data//metadata', JSON_EXTRACT(g.geometry_data, '$')
-              )
+            IF (
+              # detecting a non-kpi layer
+              l.kpi_value IS NULL,
+              JSON_ARRAY(
+                  JSON_OBJECT(
+                    'method', 'TypeMap',
+                    'mapping', l.layer_type_mapping,
+                    '//type_material', 'todo, eg: \'material\'',
+                    '//seabottom', 'todo, eg: true'
+                  )
+              ),
+              JSON_ARRAY()
             )
+          ),
+          'types', l.layer_type_types,
+          'data', CONCAT(JSON_UNQUOTE(JSON_EXTRACT(l.layer_raster, '$.url')))
+        ),
+        JSON_OBJECT(
+          #'db-layer-id', l.layer_id,
+          #'db-geometry-ids', (
+          #   SELECT JSON_ARRAYAGG(JSON_EXTRACT(geometry_id, '$'))
+          #   FROM LatestGeometryInRegion WHERE geometry_Layer_id=l.layer_id
+          # ),
+          'name', l.layer_name,
+          'display_methods', JSON_MERGE_PRESERVE(
+              IF(
+                l.layer_geotype = 'polygon',
+                JSON_ARRAY(
+                  JSON_OBJECT(
+                    'method', 'AreaModelScatter',
+                    '//type_model', 'todo, eg: \'default_model\'',
+                    '//meta_amount', 'todo, eg: \'turbines\'',
+                    '//stages', 'todo',
+                    '//stage_distribution', 'todo'
+                  ),
+                  JSON_OBJECT(
+                    'method', 'AreaColour',
+                    '//colour', 'todo, eg: \'#ffb30f\''
+                  )
+                ),
+                JSON_ARRAY()
+              ),
+              IF(
+                l.layer_geotype = 'point',
+                JSON_ARRAY(
+                  JSON_OBJECT(
+                    'method', 'PointModel',
+                    '//model', 'todo, eg: ConverterStationModel'
+                  )
+                ),
+                JSON_ARRAY()
+              ),
+              IF(
+                l.layer_geotype = 'line',
+                JSON_ARRAY(
+                  JSON_OBJECT(
+                    'method', 'LineModel',
+                    '//model', 'todo, eg: EnergyCableModel',
+                    '//meta_amount', 'todo, eg: \'number_cables\''
+                  ),
+                  JSON_OBJECT(
+                    'method', 'LineColour',
+                    '//colour', 'todo, eg: #ebff0f',
+                    '//meta_width', 'todo, eg: \'width\''
+                  )
+                ),
+                JSON_ARRAY()
+              )
+          ),
+          'types', l.layer_type_types,     
+          'data', JSON_OBJECT(
+             'points', (
+               SELECT JSON_ARRAYAGG(JSON_EXTRACT(geometry_geometry, '$'))
+               FROM LatestGeometryInRegion WHERE geometry_Layer_id=l.layer_id
+             ),
+             'types', JSON_ARRAY(JSON_EXTRACT(g.geometry_type, '$')),
+             'gaps', IF(g.geometry_gaps=JSON_ARRAY(null),JSON_ARRAY(), g.geometry_gaps),
+             # just add some aliases to the metadata
+             'metadata', JSON_MERGE_PATCH(
+               g.geometry_data,
+               JSON_OBJECT(
+                 'name', JSON_EXTRACT(g.geometry_data, '$.Name'),
+                 'turbines', JSON_EXTRACT(g.geometry_data, '$.N_TURBINES'),   
+                 '//width', 'todo, eg: 1',
+                 '//direction', 'todo, eg: true',
+                 '//number_cables', 'todo, eg: 1'
+               )
+             )
           )
-        ), '$')
-    ) as json_per_layer_type
+        )
+      )
+    ), '$') as value
   # start from layer since it holds both raster and vector layers.
   FROM LayerFinal l
   # left join since raster layers do not ever have geometry data
@@ -232,7 +378,13 @@ SQL
         }
 
         // todo: cut geometry according to coordinates
-        // todo: cut raster according to coordinates
+
+        try {
+            $this->processRasterLayers($json['datamodel']['raster_layers'], $sessionId, $coordinates);
+        } catch (\Exception $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
 
         $outputDir = $input->getOption('output-dir') . '/' . $input->getOption('output-filename');
         try {
@@ -248,5 +400,134 @@ SQL
             return Command::FAILURE;
         }
         return Command::SUCCESS;
+    }
+
+    private function processRasterLayers(array &$rasterLayers, int $sessionId, array $regionCoordinates): void
+    {
+        // cut raster according to coordinates
+        foreach ($rasterLayers as &$layer) {
+            $pathInfo = pathinfo($layer['data']);
+            // add _Cut in the filename before the extension
+            $targetFile = $pathInfo['filename'] . '_Cut.' . $pathInfo['extension'];
+
+            $targetDir = getcwd() . DIRECTORY_SEPARATOR . 'Rastermaps';
+            @mkdir($targetDir, 0777, true);
+            try {
+                $this->extractRegionFromImageByCoordinates(
+                    $this->projectDir . DIRECTORY_SEPARATOR . 'raster' . DIRECTORY_SEPARATOR . $sessionId .
+                    DIRECTORY_SEPARATOR . $layer['data'],
+                    $layer['coordinate0'][0],
+                    $layer['coordinate0'][1],
+                    $layer['coordinate1'][0],
+                    $layer['coordinate1'][1],
+                    $targetDir . DIRECTORY_SEPARATOR . $targetFile,
+                    $regionCoordinates[0],
+                    $regionCoordinates[1],
+                    $regionCoordinates[2],
+                    $regionCoordinates[3],
+                );
+            } catch (\Exception $e) {
+                throw new Exception('Could not extract region from image: ' . $e->getMessage(), 0, $e);
+            }
+            $layer['data'] = $targetFile;
+            // now set the region coordinates, clamp by input coordinates
+            $layer['coordinate0'] = [
+                min($regionCoordinates[0], $layer['coordinate1'][0]),
+                min($regionCoordinates[1], $layer['coordinate1'][1])
+            ];
+            $layer['coordinate1'] = [
+                max($regionCoordinates[2], $layer['coordinate0'][0]),
+                max($regionCoordinates[3], $layer['coordinate0'][1])
+            ];
+
+            $this->handleRasterDisplayMethods($layer);
+        }
+        unset($layer);
+    }
+
+    private function handleRasterDisplayMethods(array &$rasterLayer)
+    {
+        if (count($rasterLayer['display_methods']) == 0) {
+            return;
+        }
+
+        foreach ($rasterLayer['display_methods'] as &$displayMethod) {
+            if ($displayMethod['method'] === 'TypeMap') {
+                $m = &$displayMethod['mapping'];
+                if (count($m) == 0) {
+                    continue;
+                }
+                $maxValue = $m[count($m)-1]['max'];
+                // normalise the max values , up to 255 max. And:
+                //   set the "min" value based on the previous mapping entry's max
+                $m[0]['min'] = 0;
+                $m[0]['max'] = (int)ceil(($m[0]['max'] / $maxValue) * 255);
+                for ($n = 1; $n < count($m); ++$n) {
+                    $prevMappingEntry = &$m[$n - 1];
+                    $mappingEntry = &$m[$n];
+                    $mappingEntry['min'] = $prevMappingEntry['max']+1;
+                    $m[$n]['max'] = (int)ceil(($m[$n]['max'] / $maxValue) * 255);
+                }
+            }
+        }
+    }
+
+    private function extractRegionFromImageByCoordinates(
+        string $inputFilePath,
+        float $inputCoordinate0X, // (3450000.000, 3123736.631)
+        float $inputCoordinate0Y,
+        float $inputCoordinate1X, // (4390000.000, 4350000.000)
+        float $inputCoordinate1Y,
+        string $outputFilePath,
+        float $outputCoordinate0X, // 4048486.327 , 3470173.348
+        float $outputCoordinate0Y,
+        float $outputCoordinate1X, // 4063795.673 , 3488657.652
+        float $outputCoordinate1Y
+    ): void {
+
+        //correct y of input coordinate, the y of input coordinate 0 should be greater than input coordinate 1
+        if ($inputCoordinate0Y < $inputCoordinate1Y) {
+            $tmp = $inputCoordinate0Y;
+            $inputCoordinate0Y = $inputCoordinate1Y;
+            $inputCoordinate1Y = $tmp;
+        }
+        //correct y of output coordinate, the y of output coordinate 0 should be greater than output coordinate 1
+        if ($outputCoordinate0Y < $outputCoordinate1Y) {
+            $tmp = $outputCoordinate0Y;
+            $outputCoordinate0Y = $outputCoordinate1Y;
+            $outputCoordinate1Y = $tmp;
+        }
+
+        $image = new \Imagick();
+        $image->readImage($inputFilePath);
+        $inputWidth = $image->getImageWidth();
+        $inputHeight = $image->getImageHeight();
+
+        $coordinateToPixelWidthFactor = $inputWidth / ($inputCoordinate1X - $inputCoordinate0X);
+        $coordinateToPixelHeightFactor = $inputHeight / ($inputCoordinate1Y - $inputCoordinate0Y);
+
+        // map coordinate to the pixel coordinate of the image
+        $outputPixel0X = (int)round(($outputCoordinate0X - $inputCoordinate0X) * $coordinateToPixelWidthFactor);
+        $outputPixel0Y = (int)round(($outputCoordinate0Y -  $inputCoordinate0Y) * $coordinateToPixelHeightFactor);
+        $outputPixel1X = (int)round(($outputCoordinate1X - $inputCoordinate0X) * $coordinateToPixelWidthFactor);
+        $outputPixel1Y = (int)round(($outputCoordinate1Y -  $inputCoordinate0Y) * $coordinateToPixelHeightFactor);
+
+        // Check if output coordinates are within input range
+        $outputPixel0X = max(0, min($inputWidth - 1, $outputPixel0X));
+        $outputPixel0Y = max(0, min($inputHeight - 1, $outputPixel0Y));
+        $outputPixel1X = max(0, min($inputWidth - 1, $outputPixel1X));
+        $outputPixel1Y = max(0, min($inputHeight - 1, $outputPixel1Y));
+
+        // Calculate the size of the extracted region
+        $regionWidth = $outputPixel1X - $outputPixel0X + 1;
+        $regionHeight = $outputPixel1Y - $outputPixel0Y + 1;
+
+        if ($regionWidth <= 0 || $regionHeight <= 0) {
+            throw new \RuntimeException('Invalid region size: ' . $regionWidth . 'x' . $regionHeight);
+        }
+
+        $image->cropImage($regionWidth, $regionHeight, $outputPixel0X, $outputPixel0Y);
+        $image->setImageFormat('PNG');
+        $image->writeImage($outputFilePath);
     }
 }

--- a/src/Command/CreatePOVConfigCommand.php
+++ b/src/Command/CreatePOVConfigCommand.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace App\Command;
+
+use App\Domain\Services\ConnectionManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:create-pov-config',
+    description: 'Create a POV config json file for a session by region.',
+)]
+class CreatePOVConfigCommand extends Command
+{
+    public function __construct(
+        private readonly ConnectionManager $connectionManager
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'session-id',
+                's',
+                InputOption::VALUE_REQUIRED,
+                'The ID of the game session'
+            );
+        $this
+            ->addOption(
+                'output-dir',
+                'd',
+                InputOption::VALUE_OPTIONAL,
+                'The path to the output directory. Default is the current working directory.',
+                getcwd()
+            );
+        $this
+            ->addOption(
+                'output-filename',
+                'f',
+                InputOption::VALUE_OPTIONAL,
+                'The filename of output json file. Default is: pov-config.json',
+                'pov-config.json'
+            );
+        $this
+            ->addArgument(
+                'coordinates',
+                InputArgument::IS_ARRAY | InputArgument::REQUIRED,
+                '4 floats representing the coordinates of the region, in the order: coordinate0 x, -y, ' .
+                    'coordinate1 x, -y'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $sessionId = $input->getOption('session-id');
+        if (!ctype_digit($sessionId)) {
+            $io->error('Session ID must be an integer.');
+            return Command::FAILURE;
+        }
+        $outputDir = $input->getOption('output-dir');
+        if (!is_dir($outputDir)) {
+            $io->error('Output directory does not exist.');
+            return Command::FAILURE;
+        }
+        /** @var array $coordinates */
+        $coordinates = $input->getArgument('coordinates');
+        if (count($coordinates) !== 4) {
+            $io->error('You must specify 4 floats: coordinate0 x, -y, coordinate1 x, -y.');
+            return Command::FAILURE;
+        }
+        try {
+            $connection = $this->connectionManager->getCachedGameSessionDbConnection((int)$sessionId);
+        } catch (\Exception $e) {
+            $io->error(
+                'Could not connect to the game session database with id: ' . $sessionId . '. Error: ' . $e->getMessage()
+            );
+            return Command::FAILURE;
+        }
+
+        $jsonString = false;
+        try {
+            $result = $connection->executeQuery(<<<'SQL'
+WITH
+  # group geometries by persistent id and give row number based on geometry_id, row number 1 is the latest geometry
+  LatestGeometryStep1 AS (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY geometry_persistent ORDER BY geometry_id DESC) AS rn
+    FROM
+      geometry
+    WHERE geometry_deleted = 0 AND geometry_active = 1
+  ),
+  # filter out geometries that are not the latest, so only with row number 1
+  LatestGeometryStep2 AS (
+    SELECT * FROM LatestGeometryStep1 WHERE rn = 1
+  ),
+  # filter out geometries that are in a deleted plan, plan needs to be implemented and active
+  LatestGeometryFinal AS (
+    SELECT
+      g.*
+    FROM
+      LatestGeometryStep2 g
+    LEFT JOIN layer ON layer.layer_id=g.geometry_layer_id
+    LEFT JOIN plan_layer ON plan_layer.plan_layer_layer_id=layer.layer_id
+    LEFT JOIN plan ON (
+      plan.plan_id=plan_layer.plan_layer_plan_id AND plan.plan_state IN ('IMPLEMENTED') AND plan.plan_active = 1
+    )
+    LEFT JOIN plan_delete pd ON (
+      pd.plan_delete_plan_id=plan.plan_id AND pd.plan_delete_geometry_persistent=g.geometry_persistent
+    )
+    WHERE pd.plan_delete_geometry_persistent IS NULL
+    GROUP BY g.geometry_persistent
+  ),
+  # filter out active layers that are not in a plan or in an implemented and active plan
+  LayerFinal AS (
+      SELECT l.*
+      FROM layer l
+      LEFT JOIN plan_layer pl ON l.layer_id=pl.plan_layer_layer_id
+      LEFT JOIN plan p ON p.plan_id=pl.plan_layer_plan_id
+      WHERE l.layer_active = 1 AND  p.plan_id IS NULL OR (p.plan_state IN ('IMPLEMENTED') AND p.plan_active = 1) AND
+      (
+        l.layer_geotype IN ('line','point','polygon') OR (
+          # if raster, return only if the region overlaps with its bounding box data
+          -- l.layer_geotype IN ('raster')
+          JSON_EXTRACT(l.layer_raster, '$.boundingbox[0][0]') < :bottomRightX
+          AND JSON_EXTRACT(l.layer_raster, '$.boundingbox[0][1]') < :bottomRightY
+          AND JSON_EXTRACT(l.layer_raster, '$.boundingbox[1][0]') > :topLeftX
+          AND JSON_EXTRACT(l.layer_raster, '$.boundingbox[1][1]') > :topLeftY
+        )
+      )
+  ),
+  LatestGeometryInRegion AS (
+    SELECT *
+    FROM LatestGeometryFinal
+    # if geometry, return only the ones inside the region based on its geometry point data
+    WHERE
+      JSON_EXTRACT(geometry_geometry, '$[0][0]') BETWEEN :topLeftX AND :bottomRightX
+      AND JSON_EXTRACT(geometry_geometry, '$[0][1]') BETWEEN :topLeftY AND :bottomRightY
+  )
+SELECT
+  JSON_OBJECT(
+    'metadata',
+    JSON_OBJECT(
+      'data_modified', DATE_FORMAT(NOW(), '%d/%m/%Y')
+    ),
+    'datamodel',
+    JSON_ARRAYAGG(JSON_EXTRACT(subquery.json_per_layer_type, '$'))
+  ) as json
+FROM (
+  SELECT
+    # return the latest geometry for each layer as a json object in POV config json format
+    JSON_OBJECT(
+      IF(l.layer_geotype = 'raster', 'raster_layers', 'vector_layers'),
+        JSON_EXTRACT(JSON_OBJECTAGG(
+          l.layer_id,
+          IF(
+            l.layer_geotype = 'raster',
+            JSON_OBJECT(
+              #'db-layer-id', l.layer_id,
+              'name', l.layer_short,
+              'coordinate0', JSON_EXTRACT(l.layer_raster, '$.boundingbox[0]'),
+              'coordinate1', JSON_EXTRACT(l.layer_raster, '$.boundingbox[1]'),
+              'db-layer-type//mapping//types', JSON_EXTRACT(l.layer_type, '$.*'),
+              'data', CONCAT('RasterMaps/',JSON_UNQUOTE(JSON_EXTRACT(l.layer_raster, '$.url')))
+            ),
+            JSON_OBJECT(
+              #'db-layer-id', l.layer_id,
+              #'db-geometry-ids', (
+              #   SELECT JSON_ARRAYAGG(JSON_EXTRACT(geometry_id, '$'))
+              #   FROM LatestGeometryInRegion WHERE geometry_Layer_id=l.layer_id
+              # ),
+              'name', l.layer_name,
+#               'display_methods', JSON_OBJECT(
+#                 'stages', JSON_EXTRACT(l.layer_states, '$')
+#               ),
+              'db-types', JSON_EXTRACT(l.layer_type, '$.*'),
+              'data', JSON_OBJECT(
+                'points', (
+                  SELECT JSON_ARRAYAGG(JSON_EXTRACT(geometry_geometry, '$'))
+                  FROM LatestGeometryInRegion WHERE geometry_Layer_id=l.layer_id
+                ),
+                'db-geometry-data//metadata', JSON_EXTRACT(g.geometry_data, '$')
+              )
+            )
+          )
+        ), '$')
+    ) as json_per_layer_type
+  # start from layer since it holds both raster and vector layers.
+  FROM LayerFinal l
+  # left join since raster layers do not ever have geometry data
+  LEFT JOIN LatestGeometryInRegion as g ON g.geometry_layer_id=l.layer_id
+  WHERE l.layer_geotype IN ('raster') OR g.geometry_layer_id IS NOT NULL
+  GROUP BY IF(l.layer_geotype = 'raster', 'raster_layers', 'vector_layers')
+  ORDER BY FIELD(l.layer_geotype, 'raster', 'polygon', 'point', 'line')
+) as subquery
+SQL
+                , array_combine(
+                    [
+                        'topLeftX',
+                        'topLeftY',
+                        'bottomRightX',
+                        'bottomRightY'
+                    ],
+                    $coordinates
+                ));
+            $jsonString = $result->fetchOne();
+        } catch (\Exception $e) {
+            $io->error(
+                'Could not query the game session database with id: ' . $sessionId . '. Error: ' . $e->getMessage()
+            );
+            return Command::FAILURE;
+        }
+
+        if (!$jsonString) {
+            $io->error('No data found for the given session and coordinates.');
+            return Command::FAILURE;
+        }
+
+        try {
+            $json = json_decode($jsonString, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            $io->error('Could not decode the json string. Error: ' . $e->getMessage());
+            return Command::FAILURE;
+        }
+
+        // todo: cut geometry according to coordinates
+        // todo: cut raster according to coordinates
+
+        $outputDir = $input->getOption('output-dir') . '/' . $input->getOption('output-filename');
+        try {
+            if (!file_put_contents($outputDir, json_encode(
+                $json,
+                JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+            ))) {
+                $io->error('Could not write to output file: ' . $outputDir);
+                return Command::FAILURE;
+            }
+        } catch (\JsonException $e) {
+            $io->error('Could not encode the json string. Error: ' . $e->getMessage());
+            return Command::FAILURE;
+        }
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/CreatePOVConfigCommand.php
+++ b/src/Command/CreatePOVConfigCommand.php
@@ -4,6 +4,7 @@ namespace App\Command;
 
 use App\Domain\POV\ConfigCreator;
 use App\Domain\POV\Region;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -32,7 +33,8 @@ class CreatePOVConfigCommand extends Command
         'Eg: ' . self::ARG_REGION_COORDINATES_EXAMPLE;
 
     public function __construct(
-        private readonly string $projectDir
+        private readonly string $projectDir,
+        private LoggerInterface $logger
     ) {
         parent::__construct();
     }
@@ -49,7 +51,8 @@ class CreatePOVConfigCommand extends Command
                 self::OPT_OUTPUT_DIR,
                 'd',
                 InputOption::VALUE_REQUIRED,
-                'The path to output directory. Default is: ' . ConfigCreator::getDefaultOutputBaseDir()
+                'The path to output directory. Default is: ' .
+                    ConfigCreator::getDefaultOutputBaseDir($this->projectDir)
             );
         $this
             ->addOption(
@@ -104,7 +107,7 @@ class CreatePOVConfigCommand extends Command
         }
         $outputDir = $input->getOption(self::OPT_OUTPUT_DIR);
         $outputJsonFilename = $input->getOption(self::OPT_OUTPUT_JSON_FILENAME);
-        $configCreator = new ConfigCreator($this->projectDir, $sessionId);
+        $configCreator = new ConfigCreator($this->projectDir, $sessionId, $this->logger);
         $region = new Region(...$coordinates);
         try {
             if ($input->getOption('compress')) {

--- a/src/Command/CreatePOVConfigCommand.php
+++ b/src/Command/CreatePOVConfigCommand.php
@@ -2,8 +2,8 @@
 
 namespace App\Command;
 
-use App\Domain\Services\ConnectionManager;
-use React\MySQL\Exception;
+use App\Domain\POV\ConfigCreator;
+use App\Domain\POV\Region;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -18,8 +18,20 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 class CreatePOVConfigCommand extends Command
 {
+    const OPT_OUTPUT_DIR = 'output-dir';
+    const OPT_OUTPUT_JSON_FILENAME = 'output-json-filename';
+    const OPT_OUTPUT_PACKAGE_FILENAME = 'output-package-filename';
+    const OPT_ZIP = 'compress';
+
+    const ARG_SESSION_ID = 'session-id';
+    const ARG_REGION_COORDINATES = 'region-coordinates';
+
+    const ARG_REGION_COORDINATES_EXAMPLE = '4048536 3470232 4063746 3488599';
+    const REGION_COORDINATES_DESCRIPTION = '4 floats representing the coordinates of the region. In order:' .
+        ' region top left coordinates x, -y, region bottom right coordinates x, -y. ' .
+        'Eg: ' . self::ARG_REGION_COORDINATES_EXAMPLE;
+
     public function __construct(
-        private readonly ConnectionManager $connectionManager,
         private readonly string $projectDir
     ) {
         parent::__construct();
@@ -27,502 +39,86 @@ class CreatePOVConfigCommand extends Command
 
     protected function configure(): void
     {
+        $coordinates = array_map(
+            fn($s) => (float)$s,
+            explode(' ', self::ARG_REGION_COORDINATES_EXAMPLE)
+        );
+        $exampleRegion = new Region(...$coordinates);
         $this
             ->addOption(
-                'session-id',
-                's',
+                self::OPT_OUTPUT_DIR,
+                'd',
                 InputOption::VALUE_REQUIRED,
+                'The path to a non-existing or empty output directory. ' .
+                    'Default will be a temporary folder like: ' . ConfigCreator::getDefaultOutputDir($exampleRegion)
+            );
+        $this
+            ->addOption(
+                self::OPT_OUTPUT_JSON_FILENAME,
+                'j',
+                InputOption::VALUE_REQUIRED,
+                'The filename of output json file. Default is: ' . ConfigCreator::DEFAULT_CONFIG_FILENAME,
+                ConfigCreator::DEFAULT_CONFIG_FILENAME
+            );
+        $this
+            ->addOption(
+                self::OPT_OUTPUT_PACKAGE_FILENAME,
+                'p',
+                InputOption::VALUE_REQUIRED,
+                'The filename of compressed package file if compression is enabled. ' .
+                    'Default is: ' . ConfigCreator::DEFAULT_COMPRESSED_FILENAME,
+                ConfigCreator::DEFAULT_COMPRESSED_FILENAME
+            );
+        $this->addOption(
+            self::OPT_ZIP,
+            'z',
+            InputOption::VALUE_NONE,
+            'Enables zip compression of the output to a package file.'
+        );
+        $this
+            ->addArgument(
+                self::ARG_SESSION_ID,
+                InputArgument::REQUIRED,
                 'The ID of the game session'
             );
         $this
-            ->addOption(
-                'output-dir',
-                'd',
-                InputOption::VALUE_OPTIONAL,
-                'The path to the output directory. Default is the current working directory.',
-                getcwd()
-            );
-        $this
-            ->addOption(
-                'output-filename',
-                'f',
-                InputOption::VALUE_OPTIONAL,
-                'The filename of output json file. Default is: pov-config.json',
-                'pov-config.json'
-            );
-        $this
             ->addArgument(
-                'coordinates',
+                self::ARG_REGION_COORDINATES,
                 InputArgument::IS_ARRAY | InputArgument::REQUIRED,
-                '4 floats representing the coordinates of the region, in the order: coordinate0 x, -y, ' .
-                    'coordinate1 x, -y'
+                self::REGION_COORDINATES_DESCRIPTION
             );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        if (!extension_loaded('imagick')) {
-            $io->error('The imagick extension is not loaded.');
-            return Command::FAILURE;
-        }
-        $sessionId = $input->getOption('session-id');
+        $sessionId = $input->getArgument(self::ARG_SESSION_ID);
         if (!ctype_digit($sessionId)) {
             $io->error('Session ID must be an integer.');
             return Command::FAILURE;
         }
-        $outputDir = $input->getOption('output-dir');
-        if (!is_dir($outputDir)) {
-            $io->error('Output directory does not exist.');
-            return Command::FAILURE;
-        }
         /** @var array $coordinates */
-        $coordinates = $input->getArgument('coordinates');
+        $coordinates = $input->getArgument(self::ARG_REGION_COORDINATES);
         if (count($coordinates) !== 4) {
-            $io->error('You must specify 4 floats: coordinate0 x, -y, coordinate1 x, -y.');
+            $io->error('Invalid number of region coordinates. Required: ' . self::REGION_COORDINATES_DESCRIPTION);
             return Command::FAILURE;
         }
+        $outputDir = $input->getOption(self::OPT_OUTPUT_DIR);
+        $outputJsonFilename = $input->getOption(self::OPT_OUTPUT_JSON_FILENAME);
+        $configCreator = new ConfigCreator($this->projectDir, $sessionId);
+        $region = new Region(...$coordinates);
         try {
-            $connection = $this->connectionManager->getCachedGameSessionDbConnection((int)$sessionId);
-        } catch (\Exception $e) {
-            $io->error(
-                'Could not connect to the game session database with id: ' . $sessionId . '. Error: ' . $e->getMessage()
-            );
-            return Command::FAILURE;
-        }
-
-        $jsonString = false;
-        try {
-            $result = $connection->executeQuery(<<<'SQL'
-WITH
-  # group ecology kpis by name and give row number based on month, row number 1 is the latest kpi
-  LatestEcologyKpiStep1 AS (
-    SELECT
-      *,
-      ROW_NUMBER() OVER (PARTITION BY kpi_name ORDER BY kpi_month DESC) AS rn
-    FROM
-      kpi
-    WHERE kpi_type = 'ECOLOGY'
-  ),
-  # filter latest ecology kpis, so only with row number 1
-  LatestEcologyKpiFinal AS (
-    SELECT * FROM LatestEcologyKpiStep1 WHERE rn = 1
-  ),
-  # group non-subtractive geometries by persistent id and give row number based on geometry_id,
-  #   row number 1 is the latest geometry
-  LatestGeometryStep1 AS (
-    SELECT
-      *,
-      ROW_NUMBER() OVER (PARTITION BY geometry_persistent ORDER BY geometry_id DESC) AS rn
-    FROM
-      geometry
-    WHERE geometry_deleted = 0 AND geometry_active = 1 AND geometry_subtractive = 0
-  ),
-  # filter latest geometries, so only with row number 1
-  LatestGeometryStep2 AS (
-    SELECT * FROM LatestGeometryStep1 WHERE rn = 1
-  ),
-  # join all substractive geometries to the latest geometries and aggregate them as a json array "gaps"
-  LatestGeometryStep3 AS (
-    SELECT g.*, JSON_ARRAYAGG(JSON_EXTRACT(gs.geometry_geometry, '$')) AS geometry_gaps
-    FROM LatestGeometryStep2 g
-    LEFT JOIN geometry gs ON gs.geometry_subtractive = g.geometry_id
-    GROUP BY g.geometry_id
-  ),
-  # filter out geometries that are in a deleted plan, plan needs to be implemented and active
-  LatestGeometryFinal AS (
-    SELECT
-      g.*
-    FROM
-      LatestGeometryStep3 g
-    LEFT JOIN layer ON layer.layer_id=g.geometry_layer_id
-    LEFT JOIN plan_layer ON plan_layer.plan_layer_layer_id=layer.layer_id
-    LEFT JOIN plan ON (
-      plan.plan_id=plan_layer.plan_layer_plan_id AND plan.plan_state IN ('IMPLEMENTED') AND plan.plan_active = 1
-    )
-    LEFT JOIN plan_delete pd ON (
-      pd.plan_delete_plan_id=plan.plan_id AND pd.plan_delete_geometry_persistent=g.geometry_persistent
-    )
-    WHERE pd.plan_delete_geometry_persistent IS NULL
-    GROUP BY g.geometry_persistent
-  ),
-  # filter out active layers that are not in a plan or in an implemented and active plan
-  LayerStep1 AS (
-      SELECT l.*
-      FROM layer l
-      LEFT JOIN plan_layer pl ON l.layer_id=pl.plan_layer_layer_id
-      LEFT JOIN plan p ON p.plan_id=pl.plan_layer_plan_id
-      WHERE l.layer_active = 1 AND p.plan_id IS NULL OR (p.plan_state IN ('IMPLEMENTED') AND p.plan_active = 1) AND
-      (
-        l.layer_geotype IN ('line','point','polygon') OR (
-          # if raster, return only if the region overlaps with its bounding box data
-          -- l.layer_geotype IN ('raster')
-          JSON_EXTRACT(l.layer_raster, '$.boundingbox[0][0]') < :bottomRightX
-          AND JSON_EXTRACT(l.layer_raster, '$.boundingbox[0][1]') < :bottomRightY
-          AND JSON_EXTRACT(l.layer_raster, '$.boundingbox[1][0]') > :topLeftX
-          AND JSON_EXTRACT(l.layer_raster, '$.boundingbox[1][1]') > :topLeftY
-        )
-      )
-      GROUP BY l.layer_id
-  ),
-  # include kpi value if layer is an ecology layer and
-  #   extract new data columns from layer_type json data
-  LayerFinal AS (
-      SELECT
-        l.*,
-        k.kpi_value,
-        JSON_ARRAYAGG(JSON_OBJECT(
-          'channel', 'r',
-          'max', t.value,
-          'type', t.id
-        )) AS layer_type_mapping,
-        JSON_ARRAYAGG(JSON_OBJECT(
-          'name', t.display_name,
-          '//material', 'todo'
-        )) AS layer_type_types,
-        MIN(t.value) AS layer_type_value_min,
-        MAX(t.value) AS layer_type_value_max,
-        COUNT(t.id) as layer_type_value_count,
-        CAST((MAX(t.value) / (COUNT(t.id)-1)) as INT) as layer_type_value_step
-      FROM LayerStep1 l
-      INNER JOIN JSON_TABLE(
-        JSON_EXTRACT(l.layer_type, '$.*'),
-          '$[*]' COLUMNS (
-            id for ordinality,
-            display_name VARCHAR(255) PATH '$.displayName',
-            value int PATH '$.value'
-        )
-      ) AS t
-      LEFT JOIN LatestEcologyKpiFinal k ON (
-        l.layer_short != '' AND CONCAT('mel_',LOWER(REPLACE(k.kpi_name,' ','_'))) = l.layer_name
-      )
-      GROUP BY l.layer_id
-  ),
-  LatestGeometryInRegion AS (
-    SELECT *
-    FROM LatestGeometryFinal
-    # if geometry, return only the ones inside the region based on its geometry point data
-    WHERE
-      JSON_EXTRACT(geometry_geometry, '$[0][0]') BETWEEN :topLeftX AND :bottomRightX
-      AND JSON_EXTRACT(geometry_geometry, '$[0][1]') BETWEEN :topLeftY AND :bottomRightY
-  )
-SELECT
-  JSON_OBJECT(
-    'metadata',
-    JSON_OBJECT(
-      'data_modified', CONCAT(UTC_DATE(), ' ', UTC_TIME())
-    ),
-    'datamodel',
-    JSON_OBJECTAGG(subquery.prop, JSON_EXTRACT(subquery.value, '$.*'))
-  ) as json
-FROM (
-  SELECT
-    IF(l.layer_geotype = 'raster', 'raster_layers', 'vector_layers') as prop,
-    # return the latest geometry for each layer as a json object in POV config json format
-    JSON_EXTRACT(JSON_OBJECTAGG(
-      l.layer_id,
-      IF(
-        l.layer_geotype = 'raster',
-        JSON_OBJECT(
-          #'db-layer-id', l.layer_id,
-          'name', REPLACE(l.layer_short,'mel_',''),
-          'coordinate0', JSON_EXTRACT(l.layer_raster, '$.boundingbox[0]'),
-          'coordinate1', JSON_EXTRACT(l.layer_raster, '$.boundingbox[1]'),
-          'display_methods', JSON_MERGE_PRESERVE(
-            IF(
-              # detecting a kpi layer
-              l.kpi_value IS NOT NULL,
-              JSON_ARRAY(
-                JSON_OBJECT(
-                  'method', 'DensityFish',
-                  'scale', JSON_OBJECT(
-                    'min_value', 0,
-                    # convert from t/km2 to kg/km2, times 2 since 0.5 is the reference value
-                    'max_value', l.kpi_value * 1000 * 2,
-                    'interpolation', 'lin',
-                    '//model', 'todo, eg: \'Cod\'',
-                    '//unit_mass', 'todo, eg: 10'
-                  )
-                )
-              ),
-              JSON_ARRAY()
-            ),
-            IF (
-              # detecting a non-kpi layer
-              l.kpi_value IS NULL,
-              JSON_ARRAY(
-                  JSON_OBJECT(
-                    'method', 'TypeMap',
-                    'mapping', l.layer_type_mapping,
-                    '//type_material', 'todo, eg: \'material\'',
-                    '//seabottom', 'todo, eg: true'
-                  )
-              ),
-              JSON_ARRAY()
-            )
-          ),
-          'types', l.layer_type_types,
-          'data', CONCAT(JSON_UNQUOTE(JSON_EXTRACT(l.layer_raster, '$.url')))
-        ),
-        JSON_OBJECT(
-          #'db-layer-id', l.layer_id,
-          #'db-geometry-ids', (
-          #   SELECT JSON_ARRAYAGG(JSON_EXTRACT(geometry_id, '$'))
-          #   FROM LatestGeometryInRegion WHERE geometry_Layer_id=l.layer_id
-          # ),
-          'name', l.layer_name,
-          'display_methods', JSON_MERGE_PRESERVE(
-              IF(
-                l.layer_geotype = 'polygon',
-                JSON_ARRAY(
-                  JSON_OBJECT(
-                    'method', 'AreaModelScatter',
-                    '//type_model', 'todo, eg: \'default_model\'',
-                    '//meta_amount', 'todo, eg: \'turbines\'',
-                    '//stages', 'todo',
-                    '//stage_distribution', 'todo'
-                  ),
-                  JSON_OBJECT(
-                    'method', 'AreaColour',
-                    '//colour', 'todo, eg: \'#ffb30f\''
-                  )
-                ),
-                JSON_ARRAY()
-              ),
-              IF(
-                l.layer_geotype = 'point',
-                JSON_ARRAY(
-                  JSON_OBJECT(
-                    'method', 'PointModel',
-                    '//model', 'todo, eg: ConverterStationModel'
-                  )
-                ),
-                JSON_ARRAY()
-              ),
-              IF(
-                l.layer_geotype = 'line',
-                JSON_ARRAY(
-                  JSON_OBJECT(
-                    'method', 'LineModel',
-                    '//model', 'todo, eg: EnergyCableModel',
-                    '//meta_amount', 'todo, eg: \'number_cables\''
-                  ),
-                  JSON_OBJECT(
-                    'method', 'LineColour',
-                    '//colour', 'todo, eg: #ebff0f',
-                    '//meta_width', 'todo, eg: \'width\''
-                  )
-                ),
-                JSON_ARRAY()
-              )
-          ),
-          'types', l.layer_type_types,     
-          'data', JSON_OBJECT(
-             'points', JSON_EXTRACT(geometry_geometry, '$'),
-             'types', JSON_ARRAY(JSON_EXTRACT(g.geometry_type, '$')),
-             'gaps', IF(g.geometry_gaps=JSON_ARRAY(null),JSON_ARRAY(), g.geometry_gaps),
-             # just add some aliases to the metadata
-             'metadata', JSON_MERGE_PATCH(
-               g.geometry_data,
-               JSON_OBJECT(
-                 'name', JSON_EXTRACT(g.geometry_data, '$.Name'),
-                 'turbines', JSON_EXTRACT(g.geometry_data, '$.N_TURBINES'),   
-                 '//width', 'todo, eg: 1',
-                 '//direction', 'todo, eg: true',
-                 '//number_cables', 'todo, eg: 1'
-               )
-             )
-          )
-        )
-      )
-    ), '$') as value
-  # start from layer since it holds both raster and vector layers.
-  FROM LayerFinal l
-  # left join since raster layers do not ever have geometry data
-  LEFT JOIN LatestGeometryInRegion as g ON g.geometry_layer_id=l.layer_id
-  WHERE l.layer_geotype IN ('raster') OR g.geometry_layer_id IS NOT NULL
-  GROUP BY IF(l.layer_geotype = 'raster', 'raster_layers', 'vector_layers')
-  ORDER BY FIELD(l.layer_geotype, 'raster', 'polygon', 'point', 'line')
-) as subquery
-SQL
-                , array_combine(
-                    [
-                        'topLeftX',
-                        'topLeftY',
-                        'bottomRightX',
-                        'bottomRightY'
-                    ],
-                    $coordinates
-                ));
-            $jsonString = $result->fetchOne();
-        } catch (\Exception $e) {
-            $io->error(
-                'Could not query the game session database with id: ' . $sessionId . '. Error: ' . $e->getMessage()
-            );
-            return Command::FAILURE;
-        }
-
-        if (!$jsonString) {
-            $io->error('No data found for the given session and coordinates.');
-            return Command::FAILURE;
-        }
-
-        try {
-            $json = json_decode($jsonString, true, 512, JSON_THROW_ON_ERROR);
-        } catch (\JsonException $e) {
-            $io->error('Could not decode the json string. Error: ' . $e->getMessage());
-            return Command::FAILURE;
-        }
-
-        try {
-            $this->processRasterLayers($json['datamodel']['raster_layers'], $sessionId, $coordinates);
+            if ($input->getOption('compress')) {
+                $zipPath = $configCreator->createAndZip($region, $outputDir, $outputJsonFilename);
+                $io->success('Created config package: ' . $zipPath);
+            } else {
+                $outputDir = $configCreator->create($region, $outputDir, $outputJsonFilename);
+                $io->success('Created config in directory: ' . $outputDir);
+            }
         } catch (\Exception $e) {
             $io->error($e->getMessage());
             return Command::FAILURE;
         }
-
-        $outputDir = $input->getOption('output-dir') . '/' . $input->getOption('output-filename');
-        try {
-            if (!file_put_contents($outputDir, json_encode(
-                $json,
-                JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
-            ))) {
-                $io->error('Could not write to output file: ' . $outputDir);
-                return Command::FAILURE;
-            }
-        } catch (\JsonException $e) {
-            $io->error('Could not encode the json string. Error: ' . $e->getMessage());
-            return Command::FAILURE;
-        }
         return Command::SUCCESS;
-    }
-
-    private function processRasterLayers(array &$rasterLayers, int $sessionId, array $regionCoordinates): void
-    {
-        // cut raster according to coordinates
-        foreach ($rasterLayers as &$layer) {
-            $pathInfo = pathinfo($layer['data']);
-            // add _Cut in the filename before the extension
-            $targetFile = $pathInfo['filename'] . '_Cut.' . $pathInfo['extension'];
-
-            $targetDir = getcwd() . DIRECTORY_SEPARATOR . 'Rastermaps';
-            @mkdir($targetDir, 0777, true);
-            try {
-                $this->extractRegionFromImageByCoordinates(
-                    $this->projectDir . DIRECTORY_SEPARATOR . 'raster' . DIRECTORY_SEPARATOR . $sessionId .
-                    DIRECTORY_SEPARATOR . $layer['data'],
-                    $layer['coordinate0'][0],
-                    $layer['coordinate0'][1],
-                    $layer['coordinate1'][0],
-                    $layer['coordinate1'][1],
-                    $targetDir . DIRECTORY_SEPARATOR . $targetFile,
-                    $regionCoordinates[0],
-                    $regionCoordinates[1],
-                    $regionCoordinates[2],
-                    $regionCoordinates[3],
-                );
-            } catch (\Exception $e) {
-                throw new Exception('Could not extract region from image: ' . $e->getMessage(), 0, $e);
-            }
-            $layer['data'] = $targetFile;
-            // now set the region coordinates, clamp by input coordinates
-            $layer['coordinate0'] = [
-                min($regionCoordinates[0], $layer['coordinate1'][0]),
-                min($regionCoordinates[1], $layer['coordinate1'][1])
-            ];
-            $layer['coordinate1'] = [
-                max($regionCoordinates[2], $layer['coordinate0'][0]),
-                max($regionCoordinates[3], $layer['coordinate0'][1])
-            ];
-
-            $this->handleRasterDisplayMethods($layer);
-        }
-        unset($layer);
-    }
-
-    private function handleRasterDisplayMethods(array &$rasterLayer)
-    {
-        if (count($rasterLayer['display_methods']) == 0) {
-            return;
-        }
-
-        foreach ($rasterLayer['display_methods'] as &$displayMethod) {
-            if ($displayMethod['method'] === 'TypeMap') {
-                $m = &$displayMethod['mapping'];
-                if (count($m) == 0) {
-                    continue;
-                }
-                $maxValue = $m[count($m)-1]['max'];
-                // normalise the max values , up to 255 max. And:
-                //   set the "min" value based on the previous mapping entry's max
-                $m[0]['min'] = 0;
-                $m[0]['max'] = (int)ceil(($m[0]['max'] / $maxValue) * 255);
-                for ($n = 1; $n < count($m); ++$n) {
-                    $prevMappingEntry = &$m[$n - 1];
-                    $mappingEntry = &$m[$n];
-                    $mappingEntry['min'] = $prevMappingEntry['max']+1;
-                    $m[$n]['max'] = (int)ceil(($m[$n]['max'] / $maxValue) * 255);
-                }
-            }
-        }
-    }
-
-    private function extractRegionFromImageByCoordinates(
-        string $inputFilePath,
-        float $inputCoordinate0X, // (3450000.000, 3123736.631)
-        float $inputCoordinate0Y,
-        float $inputCoordinate1X, // (4390000.000, 4350000.000)
-        float $inputCoordinate1Y,
-        string $outputFilePath,
-        float $outputCoordinate0X, // 4048486.327 , 3470173.348
-        float $outputCoordinate0Y,
-        float $outputCoordinate1X, // 4063795.673 , 3488657.652
-        float $outputCoordinate1Y
-    ): void {
-
-        //correct y of input coordinate, the y of input coordinate 0 should be greater than input coordinate 1
-        if ($inputCoordinate0Y < $inputCoordinate1Y) {
-            $tmp = $inputCoordinate0Y;
-            $inputCoordinate0Y = $inputCoordinate1Y;
-            $inputCoordinate1Y = $tmp;
-        }
-        //correct y of output coordinate, the y of output coordinate 0 should be greater than output coordinate 1
-        if ($outputCoordinate0Y < $outputCoordinate1Y) {
-            $tmp = $outputCoordinate0Y;
-            $outputCoordinate0Y = $outputCoordinate1Y;
-            $outputCoordinate1Y = $tmp;
-        }
-
-        $image = new \Imagick();
-        $image->readImage($inputFilePath);
-        $inputWidth = $image->getImageWidth();
-        $inputHeight = $image->getImageHeight();
-
-        $coordinateToPixelWidthFactor = $inputWidth / ($inputCoordinate1X - $inputCoordinate0X);
-        $coordinateToPixelHeightFactor = $inputHeight / ($inputCoordinate1Y - $inputCoordinate0Y);
-
-        // map coordinate to the pixel coordinate of the image
-        $outputPixel0X = (int)round(($outputCoordinate0X - $inputCoordinate0X) * $coordinateToPixelWidthFactor);
-        $outputPixel0Y = (int)round(($outputCoordinate0Y -  $inputCoordinate0Y) * $coordinateToPixelHeightFactor);
-        $outputPixel1X = (int)round(($outputCoordinate1X - $inputCoordinate0X) * $coordinateToPixelWidthFactor);
-        $outputPixel1Y = (int)round(($outputCoordinate1Y -  $inputCoordinate0Y) * $coordinateToPixelHeightFactor);
-
-        // Check if output coordinates are within input range
-        $outputPixel0X = max(0, min($inputWidth - 1, $outputPixel0X));
-        $outputPixel0Y = max(0, min($inputHeight - 1, $outputPixel0Y));
-        $outputPixel1X = max(0, min($inputWidth - 1, $outputPixel1X));
-        $outputPixel1Y = max(0, min($inputHeight - 1, $outputPixel1Y));
-
-        // Calculate the size of the extracted region
-        $regionWidth = $outputPixel1X - $outputPixel0X + 1;
-        $regionHeight = $outputPixel1Y - $outputPixel0Y + 1;
-
-        if ($regionWidth <= 0 || $regionHeight <= 0) {
-            throw new \RuntimeException('Invalid region size: ' . $regionWidth . 'x' . $regionHeight);
-        }
-
-        $image->cropImage($regionWidth, $regionHeight, $outputPixel0X, $outputPixel0Y);
-        $image->setImageFormat('PNG');
-        $image->writeImage($outputFilePath);
     }
 }

--- a/src/Command/CreatePOVConfigCommand.php
+++ b/src/Command/CreatePOVConfigCommand.php
@@ -318,10 +318,7 @@ FROM (
           ),
           'types', l.layer_type_types,     
           'data', JSON_OBJECT(
-             'points', (
-               SELECT JSON_ARRAYAGG(JSON_EXTRACT(geometry_geometry, '$'))
-               FROM LatestGeometryInRegion WHERE geometry_Layer_id=l.layer_id
-             ),
+             'points', JSON_EXTRACT(geometry_geometry, '$'),
              'types', JSON_ARRAY(JSON_EXTRACT(g.geometry_type, '$')),
              'gaps', IF(g.geometry_gaps=JSON_ARRAY(null),JSON_ARRAY(), g.geometry_gaps),
              # just add some aliases to the metadata
@@ -376,8 +373,6 @@ SQL
             $io->error('Could not decode the json string. Error: ' . $e->getMessage());
             return Command::FAILURE;
         }
-
-        // todo: cut geometry according to coordinates
 
         try {
             $this->processRasterLayers($json['datamodel']['raster_layers'], $sessionId, $coordinates);

--- a/src/Controller/SessionAPI/GameController.php
+++ b/src/Controller/SessionAPI/GameController.php
@@ -15,7 +15,8 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpFoundation\Request;
 
-class GameController extends AbstractController
+class
+GameController extends AbstractController
 {
     public function __construct(
         private readonly string $projectDir

--- a/src/Controller/SessionAPI/GameController.php
+++ b/src/Controller/SessionAPI/GameController.php
@@ -15,8 +15,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpFoundation\Request;
 
-class
-GameController extends AbstractController
+class GameController extends AbstractController
 {
     public function __construct(
         private readonly string $projectDir

--- a/src/Controller/SessionAPI/GameController.php
+++ b/src/Controller/SessionAPI/GameController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Controller\SessionAPI;
+
+use App\Domain\POV\ConfigCreator;
+use App\Domain\POV\Region;
+use PHPUnit\Exception;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpFoundation\Request;
+
+class GameController extends AbstractController
+{
+    public function __construct(
+        private readonly string $projectDir
+    ) {
+    }
+
+    public function createPOVConfig(
+        int $sessionId,
+        Request $request
+    ): StreamedResponse {
+        $regionTopLeftX = $request->request->get('region_top_left_x');
+        $regionTopLeftY = $request->request->get('region_top_left_y');
+        $regionBottomRightX = $request->request->get('region_bottom_right_x');
+        $regionBottomRightY = $request->request->get('region_bottom_right_y');
+        if (!is_numeric($regionTopLeftX) ||
+            !is_numeric($regionTopLeftY) ||
+            !is_numeric($regionBottomRightX) ||
+            !is_numeric($regionBottomRightY)) {
+            throw new HttpException(Response::HTTP_BAD_REQUEST, 'Invalid region coordinates');
+        }
+
+        $region = new Region($regionTopLeftX, $regionTopLeftY, $regionBottomRightX, $regionBottomRightY);
+        $configCreator = new ConfigCreator($this->projectDir, $sessionId);
+        try {
+            $zipFilepath = $configCreator->createAndZip($region);
+        } catch (Exception $e) {
+            throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getMessage());
+        }
+
+        // Create a StreamedResponse
+        $response = new StreamedResponse(function () use ($zipFilepath) {
+            $fileStream = fopen($zipFilepath, 'rb');
+            fpassthru($fileStream);
+            fclose($fileStream);
+        });
+
+        // Set response headers
+        $response->headers->set('Content-Type', 'application/zip');
+        $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
+            ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+            basename($zipFilepath)
+        ));
+
+        // Optionally, remove the file after it has been streamed
+        $filesystem = new Filesystem();
+        $filesystem->remove($zipFilepath);
+        return $response;
+    }
+}

--- a/src/Controller/SessionAPI/UserController.php
+++ b/src/Controller/SessionAPI/UserController.php
@@ -12,18 +12,10 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class UserController extends AbstractController
 {
-
-    #[Route(
-        '/{sessionId}/api/User/RequestSession/',
-        name: 'session_api_user_request_session',
-        requirements: ['sessionId' => '\d+'],
-        methods: ['POST']
-    )]
     public function requestSession(
         int $sessionId,
         Request $request,
@@ -54,12 +46,6 @@ class UserController extends AbstractController
         }
     }
 
-    #[Route(
-        '/{sessionId}/api/User/RequestToken/',
-        name: 'session_api_user_request_token',
-        requirements: ['sessionId' => '\d+'],
-        methods: ['POST']
-    )]
     public function requestToken(
         int $sessionId,
         Request $request,

--- a/src/Domain/Helper/Util.php
+++ b/src/Domain/Helper/Util.php
@@ -2,6 +2,10 @@
 
 namespace App\Domain\Helper;
 
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
 class Util
 {
     public static function getHumanReadableSize(int $bytes): string
@@ -87,5 +91,30 @@ class Util
         }
 
         return null;
+    }
+
+    public static function removeDirectory(string $dir): void
+    {
+        // Ensure the path is a directory
+        if (!is_dir($dir)) {
+            return;
+        }
+        // Get the list of files and subdirectories in the directory
+        $files = array_diff(scandir($dir), ['.', '..']);
+
+        foreach ($files as $file) {
+            $currentPath = $dir . DIRECTORY_SEPARATOR . $file;
+
+            // Recursively remove files and subdirectories
+            if (is_dir($currentPath)) {
+                self::removeDirectory($currentPath);
+            } else {
+                // Unlink (delete) the file
+                unlink($currentPath);
+            }
+        }
+
+        // Remove the directory itself
+        rmdir($dir);
     }
 }

--- a/src/Domain/POV/ConfigCreator.php
+++ b/src/Domain/POV/ConfigCreator.php
@@ -1,0 +1,508 @@
+<?php
+
+namespace App\Domain\POV;
+
+use App\Domain\Helper\Util;
+use App\Domain\Services\ConnectionManager;
+use Doctrine\DBAL\Connection;
+use Exception;
+
+class ConfigCreator
+{
+    const DEFAULT_CONFIG_FILENAME = 'pov-config.json';
+    const DEFAULT_COMPRESSED_FILENAME = 'pov-config.zip';
+
+    const SUBDIR = 'POV';
+
+    public function __construct(
+        private readonly string $projectDir,
+        private readonly int $sessionId
+    ) {
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function getConnection(): Connection
+    {
+        return ConnectionManager::getInstance()->getCachedGameSessionDbConnection($this->sessionId);
+    }
+
+    /**
+     * @throws Exception
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function getDatabaseName(): string
+    {
+        $databaseName = $this->getConnection()->getDatabase();
+        if ($databaseName === null) {
+            throw new Exception('Could not get the database name from the connection.');
+        }
+        return $databaseName;
+    }
+
+    public function createAndZip(
+        Region $region,
+        ?string $dir = null,
+        string $configFilename = self::DEFAULT_CONFIG_FILENAME
+    ): string {
+        return '';
+    }
+
+    public static function getDefaultOutputDir(Region $region): string
+    {
+        return getcwd() . DIRECTORY_SEPARATOR . self::SUBDIR . DIRECTORY_SEPARATOR .
+            implode('-', $region->toArray());
+    }
+
+    /**
+     * @throws Exception
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function create(
+        Region $region,
+        ?string $dir = null,
+        string $configFilename = self::DEFAULT_CONFIG_FILENAME
+    ): string {
+        $dir ??= self::getDefaultOutputDir($region);
+        if (!extension_loaded('imagick')) {
+            throw new Exception('The required imagick extension is not loaded.');
+        }
+        $jsonString = $this->queryJson($region);
+        try {
+            $json = json_decode($jsonString, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Exception $e) {
+            throw new Exception('Could not decode the json string retrieved from ' . $this->getDatabaseName() .
+                '. Error: ' . $e->getMessage());
+        }
+        $this->extractRegionFromRasterLayers($region, $json['datamodel']['raster_layers'], $dir);
+        $this->createJsonConfigFile($json, $dir, $configFilename);
+        return $dir;
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function createJsonConfigFile(array &$json, string $dir, string $configFilename): void
+    {
+        $outputFilepath = $dir . DIRECTORY_SEPARATOR . $configFilename;
+        try {
+            if (!file_put_contents($outputFilepath, json_encode(
+                $json,
+                JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+            ))) {
+                throw new Exception('Could not write to output file: ' . $dir);
+            }
+        } catch (Exception $e) {
+            throw new Exception('Could not encode the json string. Error: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * @throws Exception
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function queryJson(Region $region): string
+    {
+        try {
+            $result = $this->getConnection()->executeQuery(
+                <<<'SQL'
+WITH
+  # group ecology kpis by name and give row number based on month, row number 1 is the latest kpi
+  LatestEcologyKpiStep1 AS (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY kpi_name ORDER BY kpi_month DESC) AS rn
+    FROM
+      kpi
+    WHERE kpi_type = 'ECOLOGY'
+  ),
+  # filter latest ecology kpis, so only with row number 1
+  LatestEcologyKpiFinal AS (
+    SELECT * FROM LatestEcologyKpiStep1 WHERE rn = 1
+  ),
+  # group non-subtractive geometries by persistent id and give row number based on geometry_id,
+  #   row number 1 is the latest geometry
+  LatestGeometryStep1 AS (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY geometry_persistent ORDER BY geometry_id DESC) AS rn
+    FROM
+      geometry
+    WHERE geometry_deleted = 0 AND geometry_active = 1 AND geometry_subtractive = 0
+  ),
+  # filter latest geometries, so only with row number 1
+  LatestGeometryStep2 AS (
+    SELECT * FROM LatestGeometryStep1 WHERE rn = 1
+  ),
+  # join all substractive geometries to the latest geometries and aggregate them as a json array "gaps"
+  LatestGeometryStep3 AS (
+    SELECT g.*, JSON_ARRAYAGG(JSON_EXTRACT(gs.geometry_geometry, '$')) AS geometry_gaps
+    FROM LatestGeometryStep2 g
+    LEFT JOIN geometry gs ON gs.geometry_subtractive = g.geometry_id
+    GROUP BY g.geometry_id
+  ),
+  # filter out geometries that are in a deleted plan, plan needs to be implemented and active
+  LatestGeometryFinal AS (
+    SELECT
+      g.*
+    FROM
+      LatestGeometryStep3 g
+    LEFT JOIN layer ON layer.layer_id=g.geometry_layer_id
+    LEFT JOIN plan_layer ON plan_layer.plan_layer_layer_id=layer.layer_id
+    LEFT JOIN plan ON (
+      plan.plan_id=plan_layer.plan_layer_plan_id AND plan.plan_state IN ('IMPLEMENTED') AND plan.plan_active = 1
+    )
+    LEFT JOIN plan_delete pd ON (
+      pd.plan_delete_plan_id=plan.plan_id AND pd.plan_delete_geometry_persistent=g.geometry_persistent
+    )
+    WHERE pd.plan_delete_geometry_persistent IS NULL
+    GROUP BY g.geometry_persistent
+  ),
+  # filter out active layers that are not in a plan or in an implemented and active plan
+  LayerStep1 AS (
+      SELECT l.*
+      FROM layer l
+      LEFT JOIN plan_layer pl ON l.layer_id=pl.plan_layer_layer_id
+      LEFT JOIN plan p ON p.plan_id=pl.plan_layer_plan_id
+      WHERE l.layer_active = 1 AND p.plan_id IS NULL OR (p.plan_state IN ('IMPLEMENTED') AND p.plan_active = 1) AND
+      (
+        l.layer_geotype IN ('line','point','polygon') OR (
+          # if raster, return only if the region overlaps with its bounding box data
+          -- l.layer_geotype IN ('raster')
+          JSON_EXTRACT(l.layer_raster, '$.boundingbox[0][0]') < :bottomRightX
+          AND JSON_EXTRACT(l.layer_raster, '$.boundingbox[0][1]') < :bottomRightY
+          AND JSON_EXTRACT(l.layer_raster, '$.boundingbox[1][0]') > :topLeftX
+          AND JSON_EXTRACT(l.layer_raster, '$.boundingbox[1][1]') > :topLeftY
+        )
+      )
+      GROUP BY l.layer_id
+  ),
+  # include kpi value if layer is an ecology layer and
+  #   extract new data columns from layer_type json data
+  LayerFinal AS (
+      SELECT
+        l.*,
+        k.kpi_value,
+        JSON_ARRAYAGG(JSON_OBJECT(
+          'channel', 'r',
+          'max', t.value,
+          'type', t.id
+        )) AS layer_type_mapping,
+        JSON_ARRAYAGG(JSON_OBJECT(
+          'name', t.display_name,
+          '//material', 'todo'
+        )) AS layer_type_types,
+        MIN(t.value) AS layer_type_value_min,
+        MAX(t.value) AS layer_type_value_max,
+        COUNT(t.id) as layer_type_value_count,
+        CAST((MAX(t.value) / (COUNT(t.id)-1)) as INT) as layer_type_value_step
+      FROM LayerStep1 l
+      INNER JOIN JSON_TABLE(
+        JSON_EXTRACT(l.layer_type, '$.*'),
+          '$[*]' COLUMNS (
+            id for ordinality,
+            display_name VARCHAR(255) PATH '$.displayName',
+            value int PATH '$.value'
+        )
+      ) AS t
+      LEFT JOIN LatestEcologyKpiFinal k ON (
+        l.layer_short != '' AND CONCAT('mel_',LOWER(REPLACE(k.kpi_name,' ','_'))) = l.layer_name
+      )
+      GROUP BY l.layer_id
+  ),
+  LatestGeometryInRegion AS (
+    SELECT *
+    FROM LatestGeometryFinal
+    # if geometry, return only the ones inside the region based on its geometry point data
+    WHERE
+      JSON_EXTRACT(geometry_geometry, '$[0][0]') BETWEEN :topLeftX AND :bottomRightX
+      AND JSON_EXTRACT(geometry_geometry, '$[0][1]') BETWEEN :topLeftY AND :bottomRightY
+  )
+SELECT
+  JSON_OBJECT(
+    'metadata',
+    JSON_OBJECT(
+      'data_modified', CONCAT(UTC_DATE(), ' ', UTC_TIME())
+    ),
+    'datamodel',
+    JSON_OBJECTAGG(subquery.prop, JSON_EXTRACT(subquery.value, '$.*'))
+  ) as json
+FROM (
+  SELECT
+    IF(l.layer_geotype = 'raster', 'raster_layers', 'vector_layers') as prop,
+    # return the latest geometry for each layer as a json object in POV config json format
+    JSON_EXTRACT(JSON_OBJECTAGG(
+      l.layer_id,
+      IF(
+        l.layer_geotype = 'raster',
+        JSON_OBJECT(
+          #'db-layer-id', l.layer_id,
+          'name', REPLACE(l.layer_short,'mel_',''),
+          'coordinate0', JSON_EXTRACT(l.layer_raster, '$.boundingbox[0]'),
+          'coordinate1', JSON_EXTRACT(l.layer_raster, '$.boundingbox[1]'),
+          'display_methods', JSON_MERGE_PRESERVE(
+            IF(
+              # detecting a kpi layer
+              l.kpi_value IS NOT NULL,
+              JSON_ARRAY(
+                JSON_OBJECT(
+                  'method', 'DensityFish',
+                  'scale', JSON_OBJECT(
+                    'min_value', 0,
+                    # convert from t/km2 to kg/km2, times 2 since 0.5 is the reference value
+                    'max_value', l.kpi_value * 1000 * 2,
+                    'interpolation', 'lin',
+                    '//model', 'todo, eg: \'Cod\'',
+                    '//unit_mass', 'todo, eg: 10'
+                  )
+                )
+              ),
+              JSON_ARRAY()
+            ),
+            IF (
+              # detecting a non-kpi layer
+              l.kpi_value IS NULL,
+              JSON_ARRAY(
+                  JSON_OBJECT(
+                    'method', 'TypeMap',
+                    'mapping', l.layer_type_mapping,
+                    '//type_material', 'todo, eg: \'material\'',
+                    '//seabottom', 'todo, eg: true'
+                  )
+              ),
+              JSON_ARRAY()
+            )
+          ),
+          'types', l.layer_type_types,
+          'data', CONCAT(JSON_UNQUOTE(JSON_EXTRACT(l.layer_raster, '$.url')))
+        ),
+        JSON_OBJECT(
+          #'db-layer-id', l.layer_id,
+          #'db-geometry-ids', (
+          #   SELECT JSON_ARRAYAGG(JSON_EXTRACT(geometry_id, '$'))
+          #   FROM LatestGeometryInRegion WHERE geometry_Layer_id=l.layer_id
+          # ),
+          'name', l.layer_name,
+          'display_methods', JSON_MERGE_PRESERVE(
+              IF(
+                l.layer_geotype = 'polygon',
+                JSON_ARRAY(
+                  JSON_OBJECT(
+                    'method', 'AreaModelScatter',
+                    '//type_model', 'todo, eg: \'default_model\'',
+                    '//meta_amount', 'todo, eg: \'turbines\'',
+                    '//stages', 'todo',
+                    '//stage_distribution', 'todo'
+                  ),
+                  JSON_OBJECT(
+                    'method', 'AreaColour',
+                    '//colour', 'todo, eg: \'#ffb30f\''
+                  )
+                ),
+                JSON_ARRAY()
+              ),
+              IF(
+                l.layer_geotype = 'point',
+                JSON_ARRAY(
+                  JSON_OBJECT(
+                    'method', 'PointModel',
+                    '//model', 'todo, eg: ConverterStationModel'
+                  )
+                ),
+                JSON_ARRAY()
+              ),
+              IF(
+                l.layer_geotype = 'line',
+                JSON_ARRAY(
+                  JSON_OBJECT(
+                    'method', 'LineModel',
+                    '//model', 'todo, eg: EnergyCableModel',
+                    '//meta_amount', 'todo, eg: \'number_cables\''
+                  ),
+                  JSON_OBJECT(
+                    'method', 'LineColour',
+                    '//colour', 'todo, eg: #ebff0f',
+                    '//meta_width', 'todo, eg: \'width\''
+                  )
+                ),
+                JSON_ARRAY()
+              )
+          ),
+          'types', l.layer_type_types,     
+          'data', JSON_OBJECT(
+             'points', JSON_EXTRACT(geometry_geometry, '$'),
+             'types', JSON_ARRAY(JSON_EXTRACT(g.geometry_type, '$')),
+             'gaps', IF(g.geometry_gaps=JSON_ARRAY(null),JSON_ARRAY(), g.geometry_gaps),
+             # just add some aliases to the metadata
+             'metadata', JSON_MERGE_PATCH(
+               g.geometry_data,
+               JSON_OBJECT(
+                 'name', JSON_EXTRACT(g.geometry_data, '$.Name'),
+                 'turbines', JSON_EXTRACT(g.geometry_data, '$.N_TURBINES'),   
+                 '//width', 'todo, eg: 1',
+                 '//direction', 'todo, eg: true',
+                 '//number_cables', 'todo, eg: 1'
+               )
+             )
+          )
+        )
+      )
+    ), '$') as value
+  # start from layer since it holds both raster and vector layers.
+  FROM LayerFinal l
+  # left join since raster layers do not ever have geometry data
+  LEFT JOIN LatestGeometryInRegion as g ON g.geometry_layer_id=l.layer_id
+  WHERE l.layer_geotype IN ('raster') OR g.geometry_layer_id IS NOT NULL
+  GROUP BY IF(l.layer_geotype = 'raster', 'raster_layers', 'vector_layers')
+  ORDER BY FIELD(l.layer_geotype, 'raster', 'polygon', 'point', 'line')
+) as subquery
+SQL,
+                $region->toArray()
+            );
+            $jsonString = $result->fetchOne();
+        } catch (Exception $e) {
+            throw new Exception(
+                'Could not query from ' . $this->getDatabaseName() . '. Error: ' . $e->getMessage()
+            );
+        }
+        if (!$jsonString) {
+            throw new Exception('No data found from ' . $this->getDatabaseName() . ' for the given region: ' . $region);
+        }
+        return $jsonString;
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function extractRegionFromRasterLayers(Region $region, array &$rasterLayers, string $dir): void
+    {
+        $targetDir = $dir . DIRECTORY_SEPARATOR . 'Rastermaps';
+        Util::removeDirectory($targetDir);
+        if (!mkdir($targetDir, 0777, true)) {
+            throw new Exception('Could not create directory: ' . $targetDir);
+        }
+        // cut raster according to coordinates
+        foreach ($rasterLayers as &$layer) {
+            $pathInfo = pathinfo($layer['data']);
+            // add _Cut in the filename before the extension
+            $targetFile = $pathInfo['filename'] . '_Cut.png';
+            try {
+                $this->extractPartFromImageByRegion(
+                    $this->projectDir . DIRECTORY_SEPARATOR . 'raster' . DIRECTORY_SEPARATOR .
+                        $this->sessionId . DIRECTORY_SEPARATOR . $layer['data'],
+                    new Region(
+                        $layer['coordinate0'][0],
+                        $layer['coordinate0'][1],
+                        $layer['coordinate1'][0],
+                        $layer['coordinate1'][1]
+                    ),
+                    $targetDir . DIRECTORY_SEPARATOR . $targetFile,
+                    $region
+                );
+            } catch (Exception $e) {
+                throw new Exception('Could not extract region from image: ' . $e->getMessage(), 0, $e);
+            }
+            $layer['data'] = $targetFile;
+            // now set the region coordinates, clamped by input coordinates (see extractPartFromImageByRegion)
+            $layer['coordinate0'] = $region->getTopLeft();
+            $layer['coordinate1'] = $region->getBottomRight();
+            $this->handleRasterDisplayMethods($layer);
+        }
+        unset($layer);
+    }
+
+    private function handleRasterDisplayMethods(array &$rasterLayer): void
+    {
+        if (count($rasterLayer['display_methods']) == 0) {
+            return;
+        }
+
+        foreach ($rasterLayer['display_methods'] as &$displayMethod) {
+            if ($displayMethod['method'] !== 'TypeMap') {
+                continue;
+            }
+            $m = &$displayMethod['mapping'];
+            if (count($m) == 0) {
+                continue;
+            }
+            $maxValue = $m[count($m)-1]['max'];
+            // normalise the max values , up to 255 max. And:
+            //   set the "min" value based on the previous mapping entry's max
+            $m[0]['min'] = 0;
+            $m[0]['max'] = (int)ceil(($m[0]['max'] / $maxValue) * 255);
+            for ($n = 1; $n < count($m); ++$n) {
+                $prevMappingEntry = &$m[$n - 1];
+                $mappingEntry = &$m[$n];
+                $mappingEntry['min'] = $prevMappingEntry['max']+1;
+                $m[$n]['max'] = (int)ceil(($m[$n]['max'] / $maxValue) * 255);
+            }
+        }
+    }
+
+    /**
+     * @throws \ImagickException
+     * @throws Exception
+     */
+    private function extractPartFromImageByRegion(
+        string $inputImageFilePath,
+        Region $inputRegion,
+        string $outputImageFilePath,
+        Region $outputRegion
+    ): void {
+        list($inputTopLeftX, $inputTopLeftY, $inputBottomRightX, $inputBottomRightY) =
+            array_values($inputRegion->toArray());
+        // clamp by input coordinates. The output region should be fully covered by the input region
+        $outputRegion->setTopLeftX(min($outputRegion->getTopLeftX(), $inputRegion->getBottomRightX()));
+        $outputRegion->setTopLeftY(min($outputRegion->getTopLeftY(), $inputRegion->getBottomRightY()));
+        $outputRegion->setBottomRightX(max($outputRegion->getBottomRightX(), $inputRegion->getTopLeftX()));
+        $outputRegion->setBottomRightY(max($outputRegion->getBottomRightY(), $inputRegion->getTopLeftY()));
+        list($outputTopLeftX, $outputTopLeftY, $outputBottomRightX, $outputBottomRightY) =
+            array_values($outputRegion->toArray());
+
+        //correct y of input coordinate, the y of input coordinate 0 should be greater than input coordinate 1
+        if ($inputTopLeftY < $inputBottomRightY) {
+            $tmp = $inputTopLeftY;
+            $inputTopLeftY = $inputBottomRightY;
+            $inputBottomRightY = $tmp;
+        }
+        //correct y of output coordinate, the y of output coordinate 0 should be greater than output coordinate 1
+        if ($outputTopLeftY < $outputBottomRightY) {
+            $tmp = $outputTopLeftY;
+            $outputTopLeftY = $outputBottomRightY;
+            $outputBottomRightY = $tmp;
+        }
+
+        $image = new \Imagick();
+        $image->readImage($inputImageFilePath);
+        $inputWidth = $image->getImageWidth();
+        $inputHeight = $image->getImageHeight();
+
+        $coordinateToPixelWidthFactor = $inputWidth / ($inputBottomRightX - $inputTopLeftX);
+        $coordinateToPixelHeightFactor = $inputHeight / ($inputBottomRightY - $inputTopLeftY);
+
+        // map coordinate to the pixel coordinate of the image
+        $outputPixel0X = (int)round(($outputTopLeftX - $inputTopLeftX) * $coordinateToPixelWidthFactor);
+        $outputPixel0Y = (int)round(($outputTopLeftY -  $inputTopLeftY) * $coordinateToPixelHeightFactor);
+        $outputPixel1X = (int)round(($outputBottomRightX - $inputTopLeftX) * $coordinateToPixelWidthFactor);
+        $outputPixel1Y = (int)round(($outputBottomRightY -  $inputTopLeftY) * $coordinateToPixelHeightFactor);
+
+        // Check if output coordinates are within input range
+        $outputPixel0X = max(0, min($inputWidth - 1, $outputPixel0X));
+        $outputPixel0Y = max(0, min($inputHeight - 1, $outputPixel0Y));
+        $outputPixel1X = max(0, min($inputWidth - 1, $outputPixel1X));
+        $outputPixel1Y = max(0, min($inputHeight - 1, $outputPixel1Y));
+
+        // Calculate the size of the extracted region
+        $regionWidth = $outputPixel1X - $outputPixel0X + 1;
+        $regionHeight = $outputPixel1Y - $outputPixel0Y + 1;
+
+        if ($regionWidth <= 0 || $regionHeight <= 0) {
+            throw new Exception('Invalid region size: ' . $regionWidth . 'x' . $regionHeight);
+        }
+
+        $image->cropImage($regionWidth, $regionHeight, $outputPixel0X, $outputPixel0Y);
+        $image->setImageFormat('PNG');
+        $image->writeImage($outputImageFilePath);
+    }
+}

--- a/src/Domain/POV/ConfigCreator.php
+++ b/src/Domain/POV/ConfigCreator.php
@@ -10,7 +10,6 @@ use Exception;
 class ConfigCreator
 {
     const DEFAULT_CONFIG_FILENAME = 'pov-config.json';
-    const DEFAULT_COMPRESSED_FILENAME = 'pov-config.zip';
 
     const SUBDIR = 'POV';
 
@@ -41,18 +40,41 @@ class ConfigCreator
         return $databaseName;
     }
 
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     * @throws Exception
+     */
     public function createAndZip(
         Region $region,
         ?string $dir = null,
         string $configFilename = self::DEFAULT_CONFIG_FILENAME
     ): string {
-        return '';
+        $outputDir = $this->create($region, $dir, $configFilename);
+        $zipFilename = self::getDefaultOutputBaseDir() . DIRECTORY_SEPARATOR .
+            self::getDefaultCompressedFilename($region);
+        Util::createZipFromFolder($zipFilename, $outputDir);
+        Util::removeDirectory($outputDir); // clean-up
+        return $zipFilename;
+    }
+
+    public static function getDefaultOutputBaseDir(): string
+    {
+        return getcwd() . DIRECTORY_SEPARATOR . self::SUBDIR;
     }
 
     public static function getDefaultOutputDir(Region $region): string
     {
-        return getcwd() . DIRECTORY_SEPARATOR . self::SUBDIR . DIRECTORY_SEPARATOR .
-            implode('-', $region->toArray());
+        return self::getDefaultOutputBaseDir() . DIRECTORY_SEPARATOR . self::getFoldernameFromRegion($region);
+    }
+
+    public static function getFoldernameFromRegion(Region $region): string
+    {
+        return implode('-', $region->toArray());
+    }
+
+    public static function getDefaultCompressedFilename(Region $region): string
+    {
+        return self::getFoldernameFromRegion($region) . '.zip';
     }
 
     /**

--- a/src/Domain/POV/Region.php
+++ b/src/Domain/POV/Region.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Domain\POV;
+
+class Region
+{
+    private float $topLeftX;
+    private float $topLeftY;
+    private float $bottomRightX;
+    private float $bottomRightY;
+
+    public function __construct(float $topLeftX, float $topLeftY, float $bottomRightX, float $bottomRightY)
+    {
+        $this->topLeftX = $topLeftX;
+        $this->topLeftY = $topLeftY;
+        $this->bottomRightX = $bottomRightX;
+        $this->bottomRightY = $bottomRightY;
+    }
+
+    public function getTopLeftX(): float
+    {
+        return $this->topLeftX;
+    }
+
+    public function getTopLeftY(): float
+    {
+        return $this->topLeftY;
+    }
+
+    public function getBottomRightX(): float
+    {
+        return $this->bottomRightX;
+    }
+
+    public function getBottomRightY(): float
+    {
+        return $this->bottomRightY;
+    }
+
+    public function setTopLeftX(float $topLeftX): void
+    {
+        $this->topLeftX = $topLeftX;
+    }
+
+    public function setTopLeftY(float $topLeftY): void
+    {
+        $this->topLeftY = $topLeftY;
+    }
+
+    public function setBottomRightX(float $bottomRightX): void
+    {
+        $this->bottomRightX = $bottomRightX;
+    }
+
+    public function setBottomRightY(float $bottomRightY): void
+    {
+        $this->bottomRightY = $bottomRightY;
+    }
+
+    public function getTopLeft(): array
+    {
+        return [$this->topLeftX, $this->topLeftY];
+    }
+
+    public function getBottomRight(): array
+    {
+        return [$this->bottomRightX, $this->bottomRightY];
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'topLeftX' => $this->topLeftX,
+            'topLeftY' => $this->topLeftY,
+            'bottomRightX' => $this->bottomRightX,
+            'bottomRightY' => $this->bottomRightY,
+        ];
+    }
+
+    public function __toString(): string
+    {
+        return json_encode($this->toArray());
+    }
+}

--- a/src/Domain/Services/ConnectionManager.php
+++ b/src/Domain/Services/ConnectionManager.php
@@ -34,9 +34,6 @@ class ConnectionManager extends DatabaseDefaults
         self::$instance = $this;
     }
 
-    /**
-     * @throws Exception
-     */
     public static function getInstance(): self
     {
         if (null === self::$instance) {


### PR DESCRIPTION
Export a region of the msp data either from console or api 

* For the api, post to /{sessionId}/api/Game/CreatePOVConfig will return a zip response containing the data

![image](https://github.com/BredaUniversityResearch/MSPChallenge-Server/assets/89514754/c924af7f-c6f3-4671-8678-5dc177f042a7)


* The console can output a directory or a zip file ,see below. Easy usage will be `php bin/console app:create-pov-config 1 4048536 3470232 4063746 3488599 -v`
The -v verbose option is advised to see the status notifications
```
/srv/app # php bin/console app:create-pov-config --help
Description:
  Create a POV config json file for a session by region.

Usage:
  app:create-pov-config [options] [--] <session-id> <region-coordinates>...

Arguments:
  session-id                                             The ID of the game session
  region-coordinates                                     4 floats representing the coordinates of the region. In order: region top left coordinates x, -y, region bottom right coordinates x, -y. Eg: 4048536 3470232 4063746 3488599

Options:
  -d, --output-dir=OUTPUT-DIR                            The path to output directory. Default is: /srv/app/POV
  -j, --output-json-filename=OUTPUT-JSON-FILENAME        The filename of output json file. Default is: pov-config.json [default: "pov-config.json"]
  -p, --output-package-filename=OUTPUT-PACKAGE-FILENAME  The filename of compressed package file if compression is enabled. Default is based on the region coordinates like: 4048536-3470232-4063746-3488599.zip
  -z, --compress                                         Enables zip compression of the output to a package file.
  -h, --help                                             Display help for the given command. When no command is given display help for the list command
  -q, --quiet                                            Do not output any message
  -V, --version                                          Display this application version
      --ansi|--no-ansi                                   Force (or disable --no-ansi) ANSI output
  -n, --no-interaction                                   Do not ask any interactive question
  -e, --env=ENV                                          The Environment name. [default: "dev"]
      --no-debug                                         Switch off debug mode.
  -v|vv|vvv, --verbose                                   Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

Finally, to be able to do "bash install.sh" from git bash you need a php extension imagick.
@hwarmelink I advise you do the same as me . You remove Xampp entirely and go for 
https://github.com/mlocati/powershell-phpmanager
It is a php manager from powershell (with admin rights). It works like this:

* Install it: `Install-Module -Name PhpManager -Repository PSGallery -Force`
* Install php 8.1 (that the requirement of MSP): `Install-Php -Version 8.1 -Architecture x64 -ThreadSafe 0 -Path C:\PHP -TimeZone UTC -AddToPath User`
* Check the version(s) installed (you can have multiple): `Get-Php C:\PHP`
* If you have multiple, check the doc: https://github.com/mlocati/powershell-phpmanager#working-with-multiple-php-installations
* Enable required openssl php extension: `Enable-PhpExtension openssl C:\PHP`
* Enable required curl php extension: `Enable-PhpExtension curl C:\PHP`
* Enable required intl php extension: `Enable-PhpExtension intl C:\PHP`
* Enable required sodium php extension: `Enable-PhpExtension sodium C:\PHP`
* Install imagick PECL php extension: `Install-PhpExtension imagick -MinimumStability snapshot`

I do not think you need xampp or xdebug, since we use docker for that now 

Otherwise, you could go download imagick extension for xampp (so a compiled dll binary) from https://mlocati.github.io/articles/php-windows-imagick.html. Add is to the php's ext folder etc.