### PR TITLE
removed openssl1.1-compat, it does not exist anymore. We do not need …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN apk add --no-cache \
 		file \
 		gettext \
 		git \
-        openssl1.1-compat \
         libgdiplus \
         bash \
         supervisor \


### PR DESCRIPTION
…it anymore (was for .net 5)

## Checklist before requesting a review
- [ ] I am using the Jira issue number in the commit message.
- [ ] The branch is named as the Jira issue number.
