### PR TITLE
added docker-compose.hybrid.yml which is the same as .prod.yml but with volume mapping on the root directory

### DIFF
--- a/docker-aliases.sh
+++ b/docker-aliases.sh
@@ -23,6 +23,8 @@ alias dcu="ede && $PRE_DCU && ${DCU_BASE} up -d --remove-orphans"
 alias dcux="ede && $PRE_DCU && XDEBUG_MODE=debug ${DCU_BASE} up -d --remove-orphans"
 # dcu + production (p)}
 alias dcup='ede && ([[ "${APP_ENV}" == "prod" ]] || (echo "Could not find APP_ENV=prod in dotenv" && exit 1)) && '"$PRE_DCU && ${DCU_BASE} -f docker-compose.yml -f docker-compose.prod.yml up -d --remove-orphans"
+# dcu + hybrid (h)}
+alias dcuh='ede && ([[ "${APP_ENV}" == "prod" ]] || (echo "Could not find APP_ENV=prod in dotenv" && exit 1)) && '"$PRE_DCU && ${DCU_BASE} -f docker-compose.yml -f docker-compose.hybrid.yml up -d --remove-orphans"
 ALIAS_DL_BASE="docker logs"
 [[ -z "${COMPOSE_PROJECT_NAME}" ]] && COMPOSE_PROJECT_NAME="mspchallenge"
 [[ -z "${PHP_CONTAINER}" ]] && PHP_CONTAINER="${COMPOSE_PROJECT_NAME}-php-1"

--- a/docker-compose.hybrid.yml
+++ b/docker-compose.hybrid.yml
@@ -1,0 +1,25 @@
+version: "3.7"
+
+# Production environment override
+services:
+  php:
+    build:
+      context: .
+      target: php_prod
+    volumes:
+      - ./:/srv/app
+      - ./docker/php/conf.d/app.dev.ini:/usr/local/etc/php/conf.d/app.dev.ini:ro
+      # If you develop on Mac or Windows you can remove the vendor/ directory
+      #  from the bind-mount for better performance by enabling the next line:
+      - /srv/app/vendor
+    environment:
+      APP_SECRET: ${APP_SECRET}
+      MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET}
+
+  caddy:
+    build:
+      context: .
+      target: caddy_prod
+    environment:
+      MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}
+      MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}

--- a/docker-compose.hybrid.yml
+++ b/docker-compose.hybrid.yml
@@ -8,7 +8,6 @@ services:
       target: php_prod
     volumes:
       - ./:/srv/app
-      - ./docker/php/conf.d/app.dev.ini:/usr/local/etc/php/conf.d/app.dev.ini:ro
       # If you develop on Mac or Windows you can remove the vendor/ directory
       #  from the bind-mount for better performance by enabling the next line:
       - /srv/app/vendor


### PR DESCRIPTION
added another docker compose configuration called "hybrid" which is copied from the production one with the additional volume mapping taken from "override" (=dev).
So changing files in /srv/app will be directly linked ,there is no need to rebuild the image and container