### PR TITLE
docker desktop bug-fix

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,3 +19,9 @@ services:
     environment:
       MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}
       MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}
+    ports:
+      # HTTP
+      - target: 80
+        published: ${WEB_SERVER_PORT:-${HTTP_PORT:-80}}
+        protocol: tcp
+

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -28,6 +28,11 @@ services:
       SERVER_NAME: ${SERVER_NAME:-:80}
       MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}
       MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}
+    ports:
+      # HTTP
+      - target: 80
+        published: ${WEB_SERVER_PORT:-${HTTP_PORT:-80}}
+        protocol: tcp
 
   adminer:
     image: 'mspserver-adminer-staging'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,10 +145,7 @@ services:
       - caddy_config:/config
       - ./public/:/srv/app/public/:ro
     ports:
-      # HTTP
-      - target: 80
-        published: ${WEB_SERVER_PORT:-${HTTP_PORT:-80}}
-        protocol: tcp
+      # HTTP needs to be defined in the override/prod/staging/... yml files
       # HTTPS
       - target: 443
         published: ${HTTPS_PORT:-443}


### PR DESCRIPTION
HTTP needs to be defined in the override/prod/staging/... yml files to prevent dev error: Bind for 0.0.0.0:80 failed: port is already allocated

this is because both the base and the override (dev) yml were defining a port 80

