### PR TITLE
Improved docker container setup for persistent data

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -69,6 +69,8 @@ services:
       # If you develop on Mac or Windows you can remove the vendor/ directory
       #  from the bind-mount for better performance by enabling the next line:
       - /app/vendor
+      - /app/var/cache
+      - /app/var/log
     networks:
       - mitmproxy
       - database

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,6 +5,14 @@ services:
     build:
       context: .
       target: frankenphp_prod
+    volumes:
+      - ./running_session_config/:/app/running_session_config
+      - ./raster/:/app/raster
+      - ./session_archive/:/app/session_archive
+      - ./var/log/:/app/var/log
+      - ./ServerManager/configfiles/:/app/ServerManager/configfiles
+      - ./ServerManager/session_archive/:/app/ServerManager/session_archive
+      - ./ServerManager/saves/:/app/ServerManager/saves
     environment:
       APP_SECRET: ${APP_SECRET}
       MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - database
     volumes:
       - ./docker/database/my2_80.sql:/root/my2_80.sql:ro
+      - mariadb_data:/var/lib/mysql
     logging:
       driver: "local"
 
@@ -147,6 +148,7 @@ services:
 volumes:
   caddy_data:
   caddy_config:
+  mariadb_data:
 ###> symfony/mercure-bundle ###
 ###< symfony/mercure-bundle ###
 


### PR DESCRIPTION
* presist database content among re-creation of a container
* for prod only mount folders that have persistent data
* for dev there is no need to mount the cache or log folder by default.
